### PR TITLE
feat: メンバーリストの追加

### DIFF
--- a/api/src/allocations/allocation.ts
+++ b/api/src/allocations/allocation.ts
@@ -26,7 +26,7 @@ export class Allocation {
 
   //プロジェクトID
   @Field()
-  @ManyToOne(() => Project, (project) => project.group)
+  @ManyToOne(() => Project, (project) => project.groups)
   @JoinColumn({ name: 'project_id' })
   project: Project;
 

--- a/api/src/groups/group.ts
+++ b/api/src/groups/group.ts
@@ -33,7 +33,7 @@ export class Group {
 
   //プロジェクトID
   @Field(() => Project, { defaultValue: '' })
-  @ManyToOne(() => Project, (project) => project.group)
+  @ManyToOne(() => Project, (project) => project.groups)
   @JoinColumn({ name: 'project_id' })
   project: Project;
 

--- a/api/src/groups/groups.module.ts
+++ b/api/src/groups/groups.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Group } from './group';
+import { GroupsResolver } from './groups.resolver';
+import { GroupsService } from './groups.service';
 @Module({
   imports: [TypeOrmModule.forFeature([Group])],
+  providers: [GroupsResolver, GroupsService],
 })
 export class GroupsModule {}

--- a/api/src/groups/groups.resolver.spec.ts
+++ b/api/src/groups/groups.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupsResolver } from './groups.resolver';
+
+describe('GroupsResolver', () => {
+  let resolver: GroupsResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupsResolver],
+    }).compile();
+
+    resolver = module.get<GroupsResolver>(GroupsResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/api/src/groups/groups.resolver.ts
+++ b/api/src/groups/groups.resolver.ts
@@ -1,0 +1,8 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Group } from './group';
+import { GroupsService } from './groups.service';
+
+@Resolver()
+export class GroupsResolver {
+  constructor(private groupService: GroupsService) {}
+}

--- a/api/src/groups/groups.service.spec.ts
+++ b/api/src/groups/groups.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupsService } from './groups.service';
+
+describe('GroupsService', () => {
+  let service: GroupsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupsService],
+    }).compile();
+
+    service = module.get<GroupsService>(GroupsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/src/groups/groups.service.ts
+++ b/api/src/groups/groups.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Group } from './group';
+
+@Injectable()
+export class GroupsService {
+  constructor(
+    @InjectRepository(Group)
+    private groupRepository: Repository<Group>,
+  ) {}
+}

--- a/api/src/projects/project.ts
+++ b/api/src/projects/project.ts
@@ -69,11 +69,9 @@ export class Project {
   @JoinColumn({ name: 'monster_id' })
   monster: Monster;
 
-  //1対多
-  @Field(() => Group, { defaultValue: '' })
-  @ManyToOne(() => Group, (group) => group.project)
-  @JoinColumn({ name: 'group_id' })
-  group: Group;
+  @OneToMany(() => Group, (group) => group.project)
+  @Field(() => [Group])
+  groups: Group[];
 
   @OneToMany(() => Invitation, (invitation) => invitation.project)
   @Field(() => [Invitation])

--- a/api/src/projects/projects.resolver.ts
+++ b/api/src/projects/projects.resolver.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { NewProjectInput, SelectUser } from './dto/newProject.input';
 import { Project } from './project';
@@ -22,5 +23,14 @@ export class ProjectsResolver {
       });
 
     return newProjectData;
+  }
+
+  @Mutation(() => Project)
+  async getProjectById(@Args({ name: 'id' }) id: number) {
+    const project = await this.projectService.findProjectOne(id);
+
+    if (!project) throw new NotFoundException();
+
+    return project;
   }
 }

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Group } from 'src/groups/group';
 import { Invitation } from 'src/invitations/invitation';
@@ -102,6 +106,26 @@ export class ProjectsService {
         new InternalServerErrorException();
       });
     }
+
+    return project;
+  }
+
+  findProjectOne(id: number): Promise<Project> {
+    const project = this.projectRepository.findOne(id, {
+      relations: [
+        'monster',
+        'monster.specie',
+        'invitation',
+        'list',
+        'list.listSort',
+        'task',
+        'gameLog',
+        'groups',
+        'groups.user',
+      ],
+    });
+
+    if (!project) throw new NotFoundException();
 
     return project;
   }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -104,7 +104,7 @@ type Project {
   end_date: DateTime!
   project_end_flg: Boolean!
   monster: Monster!
-  group: Group!
+  groups: [Group!]!
   invitation: [Invitation!]!
   list: [List!]!
   task: [Task!]!
@@ -162,9 +162,11 @@ type Query {
 type Mutation {
   addUser(newQualification: NewQualificationClientInput!, newInterest: NewInterestClientInput!, newUser: NewUserInput!): User!
   searchSameCompanyUsers(conditionSearchUser: SearchUserInput!): [User!]!
+  updateOnlineFlag(isOnline: Boolean!, id: String!): User!
   addQualification(newQualification: NewQualificationInput!): Qualification!
   addInterest(newInterest: NewInterestInput!): Interest!
   createProject(selectUser: SelectUser!, newProject: NewProjectInput!): Project!
+  getProjectById(id: Float!): Project!
 }
 
 input NewQualificationClientInput {

--- a/api/src/users/users.resolver.ts
+++ b/api/src/users/users.resolver.ts
@@ -59,6 +59,17 @@ export class UsersResolver {
     return sameCompanyUsers;
   }
 
+  @Mutation(() => User)
+  public async updateOnlineFlag(
+    @Args({ name: 'id' }) id: string,
+    @Args({ name: 'isOnline' }) isOnline: boolean,
+  ) {
+    const user = await this.usersService.updateOnlineFlag(id, isOnline);
+    if (!user) throw new NotFoundException({ id, isOnline });
+
+    return user;
+  }
+
   @Subscription((returns) => User, {})
   userAdded() {
     return this.pubSub.asyncIterator('userAdded');

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -98,6 +98,19 @@ export class UsersService {
     return sameCompanyUsers;
   }
 
+  async updateOnlineFlag(id: string, isOnline: boolean) {
+    const user = await this.usersRepository.findOne(id);
+
+    if (!user) throw new NotFoundException();
+
+    user.online_flg = isOnline;
+    await this.usersRepository.save(user).catch((err) => {
+      new InternalServerErrorException();
+    });
+
+    return user;
+  }
+
   // async remove(uid: string): Promise<boolean> {
   //   const result = await this.usersRepository.delete(uid);
   //   return result.affected > 0;

--- a/frontend/src/pages/auth/signUp.gql
+++ b/frontend/src/pages/auth/signUp.gql
@@ -12,7 +12,7 @@ mutation AddUser(
       id: $id
       name: $name
       icon_image: $icon_image
-      online_flg: true
+      online_flg: false
       hp: 100
       mp: 100
       occupation_id: $occupation_id

--- a/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
@@ -1,13 +1,92 @@
-import React, { FC, useEffect } from 'react';
-import { Navigate, NavLink } from 'react-router-dom';
-import { useAuthContext } from 'context/AuthProvider';
+import React, { FC, useEffect } from 'react'
+import { Navigate, NavLink, useParams } from 'react-router-dom'
+import { useAuthContext } from 'context/AuthProvider'
+import logger from 'utils/debugger/logger'
+import { useGetProjectMutation, useUpdateOnlineFlagMutation } from './projectDetail.gen'
+import { group } from 'console'
 
 export const ProjectDetail: FC = () => {
-  const { currentUser } = useAuthContext();
+  const { currentUser } = useAuthContext()
+  const { id } = useParams()
+  const [getProjectById, projectData] = useGetProjectMutation()
+  const [updateOnlineFlag, updatedUserData] = useUpdateOnlineFlagMutation()
+  const handleBeforeUnloadEvent = async (userId: string) => {
+    logger.debug('でる')
+    await updateOnlineFlag({
+      variables: {
+        id: userId,
+        isOnline: false,
+      },
+    })
+  }
+
+  useEffect(() => {
+    if (!currentUser || !id) return
+
+    const tryApi = async () => {
+      await updateOnlineFlag({
+        variables: {
+          id: currentUser.uid,
+          isOnline: true,
+        },
+      })
+
+      await getProjectById({
+        variables: {
+          id: Number(id),
+        },
+      })
+    }
+
+    tryApi()
+  }, [currentUser, id])
+
+  useEffect(() => {
+    if (!currentUser) return
+    logger.debug('入る')
+    window.addEventListener('beforeunload', () => handleBeforeUnloadEvent(currentUser.uid))
+    return () =>
+      window.removeEventListener('beforeunload', () => handleBeforeUnloadEvent(currentUser.uid))
+  }, [currentUser])
+
+  useEffect(() => {
+    logger.debug(id)
+  }, [id])
 
   return (
     <div>
       <p>プロジェクト詳細</p>
+      {projectData.data?.getProjectById.groups.map(
+        group =>
+          group.user.online_flg && (
+            <>
+              <h2>オンライン</h2>
+              <p>{group.user.name}</p>
+              <p>{group.user.icon_image}</p>
+              <p>{group.user.id}</p>
+              <p>{group.user.mp}</p>
+              <p>{group.user.hp}</p>
+              <p>{group.user.occupation_id}</p>
+              <p>{JSON.stringify(group.user.online_flg)}</p>
+            </>
+          ),
+      )}
+      {projectData.data?.getProjectById.groups.map(
+        group =>
+          !group.user.online_flg && (
+            <>
+              <h2>オフライン</h2>
+              <p>{group.user.name}</p>
+              <p>{group.user.icon_image}</p>
+              <p>{group.user.id}</p>
+              <p>{group.user.mp}</p>
+              <p>{group.user.hp}</p>
+              <p>{group.user.occupation_id}</p>
+              <p>{JSON.stringify(group.user.online_flg)}</p>
+            </>
+          ),
+      )}
+      {/* {JSON.stringify(projectData.data?.getProjectById.groups)} */}
     </div>
-  );
-};
+  )
+}

--- a/frontend/src/pages/projectList/projectDetail/projectDetail.gql
+++ b/frontend/src/pages/projectList/projectDetail/projectDetail.gql
@@ -1,0 +1,28 @@
+mutation GetProject($id: Float!) {
+  getProjectById(id: $id) {
+    id
+    name
+    hp
+    difficulty
+
+    groups {
+      user {
+        id
+        name
+        hp
+        mp
+        occupation_id
+        icon_image
+        online_flg
+      }
+    }
+  }
+}
+
+mutation UpdateOnlineFlag($id: String!, $isOnline: Boolean!) {
+  updateOnlineFlag(id: $id, isOnline: $isOnline) {
+    id
+    name
+    online_flg
+  }
+}


### PR DESCRIPTION
## 実装の概要
- プロジェクトページにてメンバーをリスト表示
- オンライン・オフラインで分ける
  - ページに来たタイミングでオンライン
  - ページを離れたタイミングでオフライン

## 目的
- 今後、正式なデザインが出来上がった時のためにデータ取得出来ている状態にするため

## レビューして欲しいところ
- オンライン・オフラインの切り替えるコード
- 外部キーを修正したprojectテーブルとgroupテーブル

## 不安に思っていること
- まだ、ソケット通信は実装していないが外部結合でデータを取ってきているのでオンライン・オフラインの状態を更新して取得できるかどうか

## スケジュール

- マージすべき日、リリースすべき日の指定があれば書く

## 関連

- 関係するプルリクエストなどがあれば書く

## 今後のタスク

- レビュアーに伝えたいタスクがあればここに記入して伝える
