### PR TITLE
fix: プロジェクト作成時、モンスターHPを0に

### DIFF
--- a/frontend/src/pages/projectList/projectList.gql
+++ b/frontend/src/pages/projectList/projectList.gql
@@ -28,7 +28,7 @@ mutation CreateProject(
     newProject: {
       name: $name
       overview: $overview
-      hp: 100
+      hp: 0
       difficulty: $difficulty
       end_date: $end_date
       project_end_flg: false


### PR DESCRIPTION
## 実装の概要
- プロジェクトの作成時、モンスターHPの初期値を0に

## 目的
- 今後、モンスターHPが変動するため

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

- マージすべき日、リリースすべき日の指定があれば書く

## 関連

- 関係するプルリクエストなどがあれば書く

## 今後のタスク

- レビュアーに伝えたいタスクがあればここに記入して伝える
