### PR TITLE
fix: projectList.gqlのHPとMPを一つに

### DIFF
--- a/frontend/src/pages/projectList/projectList.gql
+++ b/frontend/src/pages/projectList/projectList.gql
@@ -6,8 +6,6 @@ query Users($id: String!) {
     company
     hp
     mp
-    hp
-    mp
     technology
     achievement
     motivation


### PR DESCRIPTION
## 実装の概要
- `projectList.gql`にてHPとMPが二つあったので一つに

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

- マージすべき日、リリースすべき日の指定があれば書く

## 関連

- 関係するプルリクエストなどがあれば書く

## 今後のタスク

- レビュアーに伝えたいタスクがあればここに記入して伝える
