### PR TITLE
feat:フロントのdocker起動を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ coverage
 /docker/sql/data
 /api/db
 *.gen.ts
+
+db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.7"
+
+services:
+  front-server:
+    container_name: front-server
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
+    ports:
+      - "3000:3000"
+    stdin_open: true
+    volumes:
+      - type: bind
+        source: ./frontend
+        target: /front-server
+    tty: true
+
+  api-server:
+    container_name: api-server
+    build:
+      context: .
+      dockerfile: ./api/Dockerfile
+    tty: true
+    restart: always
+    ports:
+      - "3700:3700"
+    volumes:
+      - type: bind
+        source: ./api
+        target: /api-server
+    depends_on:
+      - db-server
+  db-server:
+    platform: linux/x86_64
+    container_name: db-server
+    image: mysql:5.7.29
+    volumes:
+      - ./docker/initdb.d:/docker-entrypoint-initdb.d
+      - ./db/mysql_data:/var/lib/mysql
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    ports:
+      - "10000:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: taosk_db
+      MYSQL_USER: develop
+      MYSQL_PASSWORD: password
+      TZ: "Asia/Tokyo"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:14.17.0
+
+WORKDIR /front-server
+
+ENV PATH /front-server/node_modules/.bin:$PATH
+
+COPY package*.json /front-server/
+RUN yarn
+
+COPY . /front-server
+
+CMD [ "yarn",  "start"]


### PR DESCRIPTION
## 実装の概要
- TAOSKフォルダー配下でdocker起動でapiとfrontとdbが一斉に起動するように変更

## 目的
- 開発環境の統一

## レビューして欲しいところ
- なし

## 不安に思っていること
- フロントコンテナ内でyarn install など新規のパケージのインストールが遅い気がする。docker内で通信速度制限みたいなのが掛かってる??? 調査はしてないので体感

## 起動の仕方
初回
```
 cd TAOSK 
 docker-compose up --build 

(前回のボリュームが邪魔して入らない場合はコンテナの削除もしくは下記で不要ボリュームが消される
docker volume rm `docker volume ls -q -f dangling=true`) 
```

2回目以降
```
 cd TAOSK 
 docker-compose up 

(立ち上がらなければ docker-compose down)
```

フロントのshellにはvscodeのdockerから`taosk-fron-server`を右クリックでshellに入るのが楽そう
<img width="366" alt="スクリーンショット 2021-11-17 13 11 29" src="https://user-images.githubusercontent.com/57976204/142133303-b15b5e61-64bc-4329-85e6-1ee060cd6fbc.png">

