### PR TITLE
fix: 新規登録画面の微修正 #74

### DIFF
--- a/frontend/src/components/ui/form/ImageInputField.tsx
+++ b/frontend/src/components/ui/form/ImageInputField.tsx
@@ -61,6 +61,7 @@ const StyledLabel = styled.label`
   color: ${({ theme }) => theme.COLORS.CHOCOLATE};
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_16};
   font-weight: ${({ theme }) => theme.FONT_WEIGHTS.SEMIBOLD};
+  cursor: pointer;
 `
 const StyledImageWrapper = styled.div`
   margin: 4px 0;

--- a/frontend/src/components/ui/form/ImageInputField.tsx
+++ b/frontend/src/components/ui/form/ImageInputField.tsx
@@ -26,7 +26,11 @@ export const ImageInputField: FC<Props> = ({ className }) => {
       <StyledLabel>
         プロフィール画像
         <StyledImageWrapper>
-          <StyledImage src={dottedImage} padding={dottedImage === defaultSrc ? '40px' : '0px'} />
+          <StyledImage
+            src={dottedImage}
+            alt="プロフィール画像"
+            padding={dottedImage === defaultSrc ? '40px' : '0px'}
+          />
         </StyledImageWrapper>
         <StyledDisappearedInput
           ref={inputRef}

--- a/frontend/src/components/ui/form/InputField.tsx
+++ b/frontend/src/components/ui/form/InputField.tsx
@@ -17,7 +17,6 @@ export const InputField: FC<Props> = props => {
   const [hasBlured, setHasBlured] = useState<boolean>(false)
   const {
     className,
-    marginBottom,
     labelStyles,
     inputStyles,
     errorColor = theme.COLORS.ERROR,
@@ -37,7 +36,7 @@ export const InputField: FC<Props> = props => {
 
   return (
     <div className={className}>
-      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : marginBottom}>
+      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : '24px'}>
         <StyledLabel {...labelStyles} color={shouldShowError ? errorColor : color}>
           {label}
           <StyledRequiredSpan> {required ? '*' : ''} </StyledRequiredSpan>

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -29,7 +29,11 @@ export const ItemInputField: FC<Props> = props => {
 
   return (
     <StyledWrapper className={className}>
-      {label}
+      {label}{' '}
+      <StyledItemsNum>
+        <StyledMaxItems isMax={items.length === MAX_ITEMS}>{items.length}</StyledMaxItems>/
+        {MAX_ITEMS}
+      </StyledItemsNum>
       <StyledRow>
         <StyledInput
           value={value}
@@ -71,7 +75,7 @@ export const ItemInputField: FC<Props> = props => {
 const StyledWrapper = styled.div`
   color: ${({ theme }) => theme.COLORS.CHOCOLATE};
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_16};
-  ${({ theme }) => theme.FONT_WEIGHTS.SEMIBOLD};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHTS.SEMIBOLD};
 `
 const StyledRow = styled.div`
   display: flex;
@@ -79,6 +83,12 @@ const StyledRow = styled.div`
   align-items: center;
   gap: 16px;
   margin-top: 4px;
+`
+const StyledItemsNum = styled.span`
+  font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_12};
+`
+const StyledMaxItems = styled.span<{ isMax: boolean }>`
+  color: ${({ isMax }) => isMax && theme.COLORS.ERROR};
 `
 const StyledInput = styled.input<InputAspectStyles>`
   width: ${({ width }) => width};

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -29,7 +29,7 @@ export const ItemInputField: FC<Props> = props => {
 
   return (
     <StyledWrapper className={className}>
-      {label}{' '}
+      {label}
       <StyledItemsNum>
         <StyledMaxItems isMax={items.length === MAX_ITEMS}>{items.length}</StyledMaxItems>/
         {MAX_ITEMS}
@@ -85,6 +85,7 @@ const StyledRow = styled.div`
   margin-top: 4px;
 `
 const StyledItemsNum = styled.span`
+  padding-left: 8px;
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_12};
 `
 const StyledMaxItems = styled.span<{ isMax: boolean }>`

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -5,6 +5,7 @@ import { InputItem } from 'components/ui/form/InputItem'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { useTextItems } from 'hooks/useTextItems'
 import { theme } from 'styles/theme'
+import { max } from 'consts/certificationsAndInterests'
 
 type InputAspectStyles = Record<'width' | 'height', string>
 type Props = {
@@ -18,10 +19,8 @@ type Props = {
 
 export const ItemInputField: FC<Props> = props => {
   const { className, label, placeholder, inputAspect, setItems } = props
-  const MAX_TEXT_LENGTH = 50
-  const MAX_ITEMS = 20
   const { value, items, isDisabled, onChange, onKeyPress, onClickAddButton, onClickCrossButton } =
-    useTextItems(MAX_TEXT_LENGTH, MAX_ITEMS)
+    useTextItems(max.TEXT_LENGTH, max.ITEMS)
 
   useEffect(() => {
     setItems(items.slice())
@@ -31,8 +30,8 @@ export const ItemInputField: FC<Props> = props => {
     <StyledWrapper className={className}>
       {label}
       <StyledItemsNum>
-        <StyledMaxItems isMax={items.length === MAX_ITEMS}>{items.length}</StyledMaxItems>/
-        {MAX_ITEMS}
+        <StyledMaxItems isMax={items.length === max.ITEMS}>{items.length}</StyledMaxItems>/
+        {max.ITEMS}
       </StyledItemsNum>
       <StyledRow>
         <StyledInput

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, Dispatch, KeyboardEvent, ChangeEvent } from 'react'
+import React, { FC, useState, useEffect, Dispatch, KeyboardEvent, ChangeEvent } from 'react'
 import styled from 'styled-components'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { InputItem } from 'components/ui/form/InputItem'
@@ -18,17 +18,24 @@ type Props = {
 export const ItemInputField: FC<Props> = props => {
   const { className, label, placeholder, inputAspect, items, setItems } = props
   const [value, setValue] = useState<string>('')
-  const [isDisabled, setIsDisabled] = useState<boolean>(false)
+  const [isDisabled, setIsDisabled] = useState<boolean>(true)
+  const MAX_TEXT_LENGTH = 50
+  const MAX_ITEMS = 20
+
+  const getShouldDisable = (value: string) => {
+    const isAlreadyExists = !!items.find(v => v === value)
+    const isOver = value.length > MAX_TEXT_LENGTH || items.length >= MAX_ITEMS
+    return !value.trim() || !!isAlreadyExists || isOver
+  }
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const isAlreadyExists = !!items.find(v => v === e.target.value)
-    setIsDisabled(!!isAlreadyExists)
-    setValue(e.target.value)
+    const newValue = e.target.value
+    const shouldDisabled = getShouldDisable(newValue)
+    setIsDisabled(shouldDisabled)
+    setValue(newValue)
   }
   const onClickAddButton = () => {
-    if (!value) return
-    const isAlreadyExists = !!items.find(v => v === value)
-    if (isAlreadyExists) return
+    if (isDisabled) return
     items.push(value)
     setItems(items.slice())
     setValue('')
@@ -44,6 +51,11 @@ export const ItemInputField: FC<Props> = props => {
     items.splice(index, 1)
     setItems(items.slice())
   }
+
+  useEffect(() => {
+    const shouldDisabled = getShouldDisable(value)
+    setIsDisabled(shouldDisabled)
+  }, [items])
 
   return (
     <StyledWrapper className={className}>

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useState, useEffect, Dispatch, KeyboardEvent, ChangeEvent } from 'react'
+import React, { FC, useEffect, Dispatch } from 'react'
 import styled from 'styled-components'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { InputItem } from 'components/ui/form/InputItem'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
+import { useTextItems } from 'hooks/useTextItems'
 import { theme } from 'styles/theme'
 
 type InputAspectStyles = Record<'width' | 'height', string>
@@ -16,45 +17,14 @@ type Props = {
 }
 
 export const ItemInputField: FC<Props> = props => {
-  const { className, label, placeholder, inputAspect, items, setItems } = props
-  const [value, setValue] = useState<string>('')
-  const [isDisabled, setIsDisabled] = useState<boolean>(true)
+  const { className, label, placeholder, inputAspect, setItems } = props
   const MAX_TEXT_LENGTH = 50
   const MAX_ITEMS = 20
-
-  const getShouldDisable = (value: string) => {
-    const isAlreadyExists = !!items.find(v => v === value)
-    const isOver = value.length > MAX_TEXT_LENGTH || items.length >= MAX_ITEMS
-    return !value.trim() || !!isAlreadyExists || isOver
-  }
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value
-    const shouldDisabled = getShouldDisable(newValue)
-    setIsDisabled(shouldDisabled)
-    setValue(newValue)
-  }
-  const onClickAddButton = () => {
-    if (isDisabled) return
-    items.push(value)
-    setItems(items.slice())
-    setValue('')
-  }
-  const onKeyPress = (e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      onClickAddButton()
-    }
-  }
-  const onClickCrossButton = (item: string) => {
-    const index = items.indexOf(item)
-    items.splice(index, 1)
-    setItems(items.slice())
-  }
+  const { value, items, isDisabled, onChange, onKeyPress, onClickAddButton, onClickCrossButton } =
+    useTextItems(MAX_TEXT_LENGTH, MAX_ITEMS)
 
   useEffect(() => {
-    const shouldDisabled = getShouldDisable(value)
-    setIsDisabled(shouldDisabled)
+    setItems(items.slice())
   }, [items])
 
   return (

--- a/frontend/src/components/ui/form/SelectField.tsx
+++ b/frontend/src/components/ui/form/SelectField.tsx
@@ -21,7 +21,6 @@ export const SelectField: FC<Props> = props => {
   const [hasBlured, setHasBlured] = useState<boolean>(false)
   const {
     className,
-    marginBottom,
     labelStyles,
     selectStyles,
     options,
@@ -46,7 +45,7 @@ export const SelectField: FC<Props> = props => {
 
   return (
     <div className={className}>
-      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : marginBottom}>
+      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : '24px'}>
         <StyledLabel {...labelStyles} color={shouldShowError ? errorColor : undefined}>
           {label}
           <StyledRequiredSpan> {required ? '*' : ''} </StyledRequiredSpan>

--- a/frontend/src/components/ui/header/AuthHeader.tsx
+++ b/frontend/src/components/ui/header/AuthHeader.tsx
@@ -26,7 +26,7 @@ export const AuthHeader: FC = () => {
   return (
     <StyledHeaderWrapper>
       <StyledLogoWrapper>
-        <img src="svg/logo-transparent-background.svg" alt="" />
+        <img src="svg/logo-transparent-background.svg" alt="TAoSK ロゴ" />
       </StyledLogoWrapper>
 
       <StyledButtonsWrapper>

--- a/frontend/src/consts/certificationsAndInterests.ts
+++ b/frontend/src/consts/certificationsAndInterests.ts
@@ -1,0 +1,4 @@
+export const max = {
+  TEXT_LENGTH: 50,
+  ITEMS: 20,
+} as const

--- a/frontend/src/hooks/useTextItems.ts
+++ b/frontend/src/hooks/useTextItems.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, KeyboardEventHandler, ChangeEventHandler } from 'react'
+
+type UseTextItemsReturn = {
+  value: string
+  items: string[]
+  isDisabled: boolean
+  onChange: ChangeEventHandler<HTMLInputElement>
+  onKeyPress: KeyboardEventHandler<HTMLInputElement>
+  onClickAddButton: () => void
+  onClickCrossButton: (item: string) => void
+}
+
+export const useTextItems = (maxTextLength: number, maxItems: number): UseTextItemsReturn => {
+  const [items, setItems] = useState<string[]>([])
+  const [value, setValue] = useState<string>('')
+  const [isDisabled, setIsDisabled] = useState<boolean>(true)
+
+  const getShouldDisable = (value: string) => {
+    const isAlreadyExists = !!items.find(v => v === value)
+    const isOver = value.length > maxTextLength || items.length >= maxItems
+    return !value.trim() || !!isAlreadyExists || isOver
+  }
+
+  const onChange: ChangeEventHandler<HTMLInputElement> = e => {
+    const newValue = e.target.value
+    const shouldDisabled = getShouldDisable(newValue)
+    setIsDisabled(shouldDisabled)
+    setValue(newValue)
+  }
+  const onClickAddButton = () => {
+    if (isDisabled) return
+    items.push(value)
+    setItems(items.slice())
+    setValue('')
+  }
+  const onKeyPress: KeyboardEventHandler<HTMLInputElement> = e => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onClickAddButton()
+    }
+  }
+  const onClickCrossButton = (item: string) => {
+    const index = items.indexOf(item)
+    items.splice(index, 1)
+    setItems(items.slice())
+  }
+
+  useEffect(() => {
+    const shouldDisabled = getShouldDisable(value)
+    setIsDisabled(shouldDisabled)
+  }, [items])
+
+  return { value, items, isDisabled, onChange, onKeyPress, onClickAddButton, onClickCrossButton }
+}

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -21,7 +21,7 @@ export const SignIn: FC = () => {
       <AuthHeader />
       <StyledWrapper>
         <StyledSignIn>
-          <StyledLogoImg src={'logo.png'} />
+          <StyledLogoImg src="logo.png" alt="TAoSK ロゴ" />
           <StyledFormWrapper>
             <StyledInputField
               label="メールアドレス"

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -23,12 +23,16 @@ export const SignIn: FC = () => {
         <StyledSignIn>
           <StyledLogoImg src="logo.png" alt="TAoSK ロゴ" />
           <StyledFormWrapper>
-            <StyledInputField
+            <InputField
               label="メールアドレス"
               type="email"
               registration={register('email', { required: true })}
+              inputStyles={{
+                border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
+                borderRadius: '2px',
+              }}
             />
-            <StyledPasswordField
+            <PasswordField
               label="パスワード"
               registration={register('password', { required: true })}
             />
@@ -101,16 +105,6 @@ const StyledFormWrapper = styled.div`
 const StyledLogoImg = styled.img`
   height: 170px;
 `
-const StyledInputField = styled(InputField).attrs(() => ({
-  inputStyles: {
-    border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
-    borderRadius: '2px',
-  },
-  marginBottom: '28px',
-}))``
-const StyledPasswordField = styled(PasswordField).attrs(() => ({
-  marginBottom: '24px',
-}))``
 const StyledParagraphWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -35,7 +35,7 @@ export const SignUp: FC = () => {
       <AuthHeader />
       <StyledWrapper>
         <StyledSignUp>
-          <StyledLogoImg src={'logo.png'} />
+          <StyledLogoImg src="logo.png" alt="TAoSK ロゴ" />
           <StyledH1>新規登録書</StyledH1>
           <StyledFormWrapper>
             <StyledImageInputField
@@ -120,13 +120,13 @@ export const SignUp: FC = () => {
                 label="保有資格"
                 items={certifications}
                 setItems={setCertifications}
-                placeholder={'保有資格を入力してください'}
+                placeholder="保有資格を入力してください"
               />
               <StyledItemInputField
                 label="興味のあること"
                 items={interests}
                 setItems={setInterests}
-                placeholder={'興味のあることを入力してください'}
+                placeholder="興味のあることを入力してください"
               />
 
               <StyledTerms>

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -30,6 +30,11 @@ export const SignUp: FC = () => {
   })
   occupationOptions.unshift({ value: '', item: '選択' })
 
+  const inputStyles = {
+    border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
+    borderRadius: '2px',
+  }
+
   return (
     <>
       <AuthHeader />
@@ -42,7 +47,7 @@ export const SignUp: FC = () => {
               margin={innerWidth <= 1210 ? '0 auto 24px auto' : '0 0 24px 0'}
             />
             <StyledRightColumn margin={innerWidth <= 1210 ? '0 auto 24px auto' : '0 0 24px 0'}>
-              <StyledInputField
+              <InputField
                 label="冒険者"
                 registration={register('name', {
                   required: '未入力です',
@@ -52,9 +57,10 @@ export const SignUp: FC = () => {
                   },
                   pattern: REGEX_TEXT,
                 })}
+                inputStyles={inputStyles}
                 error={errors['name']}
               />
-              <StyledInputField
+              <InputField
                 label="会社名"
                 registration={register('company', {
                   required: '未入力です',
@@ -64,9 +70,10 @@ export const SignUp: FC = () => {
                   },
                   pattern: REGEX_TEXT,
                 })}
+                inputStyles={inputStyles}
                 error={errors['company']}
               />
-              <StyledInputField
+              <InputField
                 label="メールアドレス"
                 registration={register('email', {
                   required: '未入力です',
@@ -79,9 +86,10 @@ export const SignUp: FC = () => {
                     message: '不正なメールアドレスです',
                   },
                 })}
+                inputStyles={inputStyles}
                 error={errors['email']}
               />
-              <StyledPasswordField
+              <PasswordField
                 label="パスワード"
                 registration={register('password', {
                   required: '未入力です',
@@ -101,7 +109,7 @@ export const SignUp: FC = () => {
                 onChange={() => trigger('re-password')}
                 error={errors['password']}
               />
-              <StyledPasswordField
+              <PasswordField
                 label="パスワード（確認）"
                 registration={register('re-password', {
                   required: '未入力です',
@@ -110,7 +118,7 @@ export const SignUp: FC = () => {
                 onChange={() => trigger('password')}
                 error={errors['re-password']}
               />
-              <StyledSelectField
+              <SelectField
                 label="職種"
                 registration={register('occupation', { required: '未選択です' })}
                 options={occupationOptions}
@@ -120,12 +128,14 @@ export const SignUp: FC = () => {
                 label="保有資格"
                 items={certifications}
                 setItems={setCertifications}
+                inputAspect={{ width: '400px', height: '40px' }}
                 placeholder="保有資格を入力してください"
               />
               <StyledItemInputField
                 label="興味のあること"
                 items={interests}
                 setItems={setInterests}
+                inputAspect={{ width: '400px', height: '40px' }}
                 placeholder="興味のあることを入力してください"
               />
 
@@ -215,22 +225,7 @@ const StyledImageInputField = styled(ImageInputField).attrs<{ margin: string }>(
 }))<{ margin: string }>`
   margin: ${({ margin }) => margin};
 `
-const StyledInputField = styled(InputField).attrs(() => ({
-  inputStyles: {
-    border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
-    borderRadius: '2px',
-  },
-  marginBottom: '24px',
-}))``
-const StyledPasswordField = styled(PasswordField).attrs(() => ({
-  marginBottom: '24px',
-}))``
-const StyledSelectField = styled(SelectField).attrs(() => ({
-  marginBottom: '24px',
-}))``
-const StyledItemInputField = styled(ItemInputField).attrs(() => ({
-  inputAspect: { width: '400px', height: '40px' },
-}))`
+const StyledItemInputField = styled(ItemInputField)`
   margin-bottom: 24px;
 `
 const StyledBackground = styled.div`

--- a/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
@@ -407,7 +407,7 @@ export const ProjectDetail: FC = () => {
       <ProjectTitleContainer>
         プロジェクト詳細
         <button style={{ border: 'solid' }}>招待</button>
-        <input type="text" {...inputUserName} placeholder={'ユーザ名'} />
+        <input type="text" {...inputUserName} placeholder="ユーザ名" />
         {debouncedInputText &&
           searchSameCompanyUsersData.data?.searchSameCompanyUsers.map(searchSameCompanyUsers =>
             selectUserIds.includes(searchSameCompanyUsers.id) ? (

--- a/frontend/src/types/fieldProps.ts
+++ b/frontend/src/types/fieldProps.ts
@@ -3,7 +3,6 @@ import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 export type StyledLabelProps = { color?: string; fontSize?: string }
 export type FieldProps<T, U extends string, V> = {
   className?: string
-  marginBottom: string
   labelStyles?: StyledLabelProps
   label?: string
   error?: FieldError | undefined


### PR DESCRIPTION
## 実装の概要

主に資格/興味部分の要件の追加に合わせて微修正を行なった

- 画像のところにカーソルを合わせたらpointerになるようにした
- 興味/資格
  - 追加時に空白を弾く
  - 興味/資格の横に n / 20 の表示をする
  - 興味/資格の上限を20個までとする
  - 興味/資格の文字数制限を50文字までとする
- imgにalt属性をつける
- styles-componentで余分にattr使っている部分の可読性が低かったので削除してpropsで渡すようにした
  - marginBottomを全て削除した
- 興味/資格の最大文字数、最大数に関しては、constsフォルダに格納した
 
![スクリーンショット 2021-11-24 21 24 32](https://user-images.githubusercontent.com/47961006/143246431-0ad633d2-fd22-41a4-bcbf-50ca0b9efe9d.png)



Trello #74 
Closes #74 

## 目的
- 資格/興味部分を微修正してUXを上げる
- 細かなリファクタを行い可読性を上げる

## レビューして欲しいところ
- itemsの管理部分は `useTextItems.ts` というフックに分けた
  - 見た目以外のロジック全部切り出したいなと思ったため
  - メンバー追加時など、他に使える場面があるかもしれないため
  - この切り出し方は適切かどうか

## 不安に思っていること

## スケジュール

- マージすべき日、リリースすべき日の指定があれば書く

## 関連

- 関係するプルリクエストなどがあれば書く

## 今後のタスク
新規登録の横スクロールが若干できてしまう問題に関して、自分の環境では再現できなかったので別issueとする

Chromeで検証から画面サイズを変えたり、大きめのディスプレイで表示したりMacbook pro 13inchi上で表示したりと色々試したが、再現できなかった
