### PR TITLE
PC上ではカンプ通りのデザインで表示されるようにした

### DIFF
--- a/frontend/src/components/ui/button/SimpleRoundedButton.tsx
+++ b/frontend/src/components/ui/button/SimpleRoundedButton.tsx
@@ -1,5 +1,6 @@
 import React, { FC, MouseEvent } from 'react'
 import styled from 'styled-components'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 import { theme } from 'styles/theme'
 
 type Props = {
@@ -37,8 +38,8 @@ const StyledButton = styled.button<StyledButtonProps>`
   text-align: center;
 `
 StyledButton.defaultProps = {
-  width: '120px',
-  height: '40px',
+  width: calculateVwBasedOnFigma(120),
+  height: calculateVwBasedOnFigma(40),
   border: 'none',
   borderRadius: '2px',
   bgColor: theme.COLORS.DODGER_BLUE,

--- a/frontend/src/components/ui/form/ImageInputField.tsx
+++ b/frontend/src/components/ui/form/ImageInputField.tsx
@@ -5,6 +5,7 @@ import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import styled from 'styled-components'
 import { theme } from 'styles/theme'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type Props = { className?: string }
 
@@ -29,7 +30,7 @@ export const ImageInputField: FC<Props> = ({ className }) => {
           <StyledImage
             src={dottedImage}
             alt="プロフィール画像"
-            padding={dottedImage === defaultSrc ? '40px' : '0px'}
+            padding={dottedImage === defaultSrc ? calculateVwBasedOnFigma(40) : '0px'}
           />
         </StyledImageWrapper>
         <StyledDisappearedInput
@@ -43,8 +44,8 @@ export const ImageInputField: FC<Props> = ({ className }) => {
       <StyledCoarseButton
         text="画像をアップロード"
         aspect={{
-          width: '190px',
-          height: '40px',
+          width: calculateVwBasedOnFigma(190),
+          height: calculateVwBasedOnFigma(40),
         }}
         outerBgColor={convertIntoRGBA(theme.COLORS.TEMPTRESS, 0.2)}
         innerBgColor={convertIntoRGBA(theme.COLORS.RED_OXIDE, 0.45)}
@@ -68,9 +69,9 @@ const StyledLabel = styled.label`
   cursor: pointer;
 `
 const StyledImageWrapper = styled.div`
-  margin: 4px 0;
-  width: 190px;
-  height: 190px;
+  margin: ${calculateVwBasedOnFigma(4)} 0;
+  width: ${calculateVwBasedOnFigma(190)};
+  height: ${calculateVwBasedOnFigma(190)};
   border: 1px solid ${({ theme }) => theme.COLORS.CHOCOLATE};
   border-radius: 2px;
   background-color: ${({ theme }) => theme.COLORS.WHITE};
@@ -85,11 +86,11 @@ const StyledDisappearedInput = styled.input`
   display: none;
 `
 const StyledCoarseButton = styled(CoarseButton)`
-  margin: 4px 0;
+  margin: ${calculateVwBasedOnFigma(4)} 0;
   box-shadow: 0px 2px 4px 0px ${({ theme }) => convertIntoRGBA(theme.COLORS.BLACK, 0.25)};
 `
 const StyledDeleteButton = styled.button`
-  margin: 4px 0;
+  margin: ${calculateVwBasedOnFigma(4)} 0;
   color: ${({ theme }) => theme.COLORS.CHOCOLATE};
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
 `

--- a/frontend/src/components/ui/form/InputField.tsx
+++ b/frontend/src/components/ui/form/InputField.tsx
@@ -3,6 +3,7 @@ import type { StyledLabelProps, FieldProps } from 'types/fieldProps'
 import styled from 'styled-components'
 import { theme } from 'styles/theme'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type StyledBoxProps = {
   width?: string
@@ -36,7 +37,7 @@ export const InputField: FC<Props> = props => {
 
   return (
     <div className={className}>
-      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : '24px'}>
+      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : calculateVwBasedOnFigma(24)}>
         <StyledLabel {...labelStyles} color={shouldShowError ? errorColor : color}>
           {label}
           <StyledRequiredSpan> {required ? '*' : ''} </StyledRequiredSpan>
@@ -69,11 +70,11 @@ StyledLabel.defaultProps = {
   fontSize: theme.FONT_SIZES.SIZE_16,
 }
 const StyledInputWrapper = styled.div<StyledBoxProps>`
-  margin-top: 4px;
+  margin-top: ${calculateVwBasedOnFigma(4)};
   input {
     width: ${({ width }) => width};
     height: ${({ height }) => height};
-    padding-left: 8px;
+    padding-left: ${calculateVwBasedOnFigma(8)};
     border: ${({ border }) => border};
     border-radius: ${({ borderRadius }) => borderRadius};
     background-color: ${({ backgroundColor }) => backgroundColor};
@@ -84,7 +85,7 @@ const StyledInputWrapper = styled.div<StyledBoxProps>`
 `
 StyledInputWrapper.defaultProps = {
   width: '100%',
-  height: '40px',
+  height: calculateVwBasedOnFigma(40),
   border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
   borderRadius: '2px',
   backgroundColor: convertIntoRGBA(theme.COLORS.WHITE, 0.7),

--- a/frontend/src/components/ui/form/InputItem.tsx
+++ b/frontend/src/components/ui/form/InputItem.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { CrossButton } from 'components/ui/button/CrossButton'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { theme } from 'styles/theme'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type Props = {
   className?: string
@@ -50,27 +51,28 @@ const StyledTextWrapper = styled.div`
   align-items: center;
 `
 const StyledText = styled.span`
-  padding: 2px 10px;
+  padding: ${calculateVwBasedOnFigma(2)} ${calculateVwBasedOnFigma(10)};
 `
 const StyledCrossButton = styled(CrossButton)`
   height: 100%;
-  padding: 10px 7px 10px 0;
+  padding: ${calculateVwBasedOnFigma(10)} ${calculateVwBasedOnFigma(7)}
+    ${calculateVwBasedOnFigma(10)} 0;
   svg {
-    width: 8px;
-    height: 8px;
+    width: ${calculateVwBasedOnFigma(8)};
+    height: ${calculateVwBasedOnFigma(8)};
   }
 `
 const StyledInnerBackground = styled.div`
   z-index: ${({ theme }) => theme.Z_INDEX.INDEX_1};
   position: absolute;
   opacity: 0.8;
-  top: calc(50% + 0.5px);
+  top: calc(50% + ${calculateVwBasedOnFigma(0.5)});
   left: 50%;
   transform: translate(-50%, -50%);
   -webkit-transform: translate(-50%, -50%);
   -ms-transform: translate(-50%, -50%);
-  width: calc(100% - 4px);
-  height: calc(100% - 4px);
+  width: calc(100% - ${calculateVwBasedOnFigma(4)});
+  height: calc(100% - ${calculateVwBasedOnFigma(4)});
   border-radius: 2px;
   background-image: url('light-grain.png');
   background-size: cover;

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -5,6 +5,7 @@ import { InputItem } from 'components/ui/form/InputItem'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { useTextItems } from 'hooks/useTextItems'
 import { theme } from 'styles/theme'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type InputAspectStyles = Record<'width' | 'height', string>
 type Props = {
@@ -45,8 +46,8 @@ export const ItemInputField: FC<Props> = props => {
         <CoarseButton
           text="追加"
           aspect={{
-            width: '64px',
-            height: '40px',
+            width: calculateVwBasedOnFigma(64),
+            height: calculateVwBasedOnFigma(40),
           }}
           outerBgColor={
             isDisabled
@@ -81,11 +82,11 @@ const StyledRow = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 16px;
-  margin-top: 4px;
+  gap: ${calculateVwBasedOnFigma(16)};
+  margin-top: ${calculateVwBasedOnFigma(4)};
 `
 const StyledItemsNum = styled.span`
-  padding-left: 8px;
+  padding-left: ${calculateVwBasedOnFigma(8)};
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_12};
 `
 const StyledMaxItems = styled.span<{ isMax: boolean }>`
@@ -94,7 +95,7 @@ const StyledMaxItems = styled.span<{ isMax: boolean }>`
 const StyledInput = styled.input<InputAspectStyles>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
-  padding-left: 8px;
+  padding-left: ${calculateVwBasedOnFigma(8)};
   background-color: ${({ theme }) => convertIntoRGBA(theme.COLORS.WHITE, 0.7)};
   border: solid 1px ${({ theme }) => theme.COLORS.CHOCOLATE};
   border-radius: 2px;
@@ -106,7 +107,7 @@ const StyledItemsWrapper = styled.div<{ width: string }>`
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
-  gap: 12px;
-  margin-top: 12px;
+  gap: ${calculateVwBasedOnFigma(12)};
+  margin-top: ${calculateVwBasedOnFigma(12)};
   width: ${({ width }) => width};
 `

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -26,7 +26,7 @@ export const ItemInputField: FC<Props> = props => {
 
   useEffect(() => {
     setItems(items.slice())
-  }, [items])
+  }, [setItems, items])
 
   return (
     <StyledWrapper className={className}>
@@ -101,6 +101,7 @@ const StyledInput = styled.input<InputAspectStyles>`
   border-radius: 2px;
   &::placeholder {
     color: ${({ theme }) => theme.COLORS.GRAY};
+    font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
   }
 `
 const StyledItemsWrapper = styled.div<{ width: string }>`

--- a/frontend/src/components/ui/form/PasswordField.tsx
+++ b/frontend/src/components/ui/form/PasswordField.tsx
@@ -5,6 +5,7 @@ import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { InputField } from 'components/ui/form/InputField'
 import type { FieldProps } from 'types/fieldProps'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type StyledBoxProps = {
   width?: string
@@ -41,8 +42,8 @@ export const PasswordField: FC<Props> = ({
       <StyledCoarseButton
         text={shouldShowPassword ? '非表示' : '表示'}
         aspect={{
-          width: '53px',
-          height: '30px',
+          width: calculateVwBasedOnFigma(53),
+          height: calculateVwBasedOnFigma(30),
         }}
         outerBgColor={
           value
@@ -67,6 +68,6 @@ const StyledWrapper = styled.div`
 `
 const StyledCoarseButton = styled(CoarseButton)`
   position: absolute;
-  top: 36px;
-  right: 7px;
+  top: ${calculateVwBasedOnFigma(36)};
+  right: ${calculateVwBasedOnFigma(7)};
 `

--- a/frontend/src/components/ui/form/SelectField.tsx
+++ b/frontend/src/components/ui/form/SelectField.tsx
@@ -3,6 +3,7 @@ import type { StyledLabelProps, FieldProps } from 'types/fieldProps'
 import styled from 'styled-components'
 import { theme } from 'styles/theme'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type StyledSelectProps = {
   width?: string
@@ -45,7 +46,7 @@ export const SelectField: FC<Props> = props => {
 
   return (
     <div className={className}>
-      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : '24px'}>
+      <StyledLabelWrapper marginBottom={shouldShowError ? '0px' : calculateVwBasedOnFigma(24)}>
         <StyledLabel {...labelStyles} color={shouldShowError ? errorColor : undefined}>
           {label}
           <StyledRequiredSpan> {required ? '*' : ''} </StyledRequiredSpan>
@@ -89,35 +90,35 @@ StyledLabel.defaultProps = {
 }
 const StyledSelectWrapper = styled.div<{ height?: string }>`
   position: relative;
-  margin-top: 4px;
+  margin-top: ${calculateVwBasedOnFigma(4)};
 
   &:after {
     content: '';
     position: absolute;
-    top: calc(${({ height }) => height} / 2 - 2px);
-    right: 14px;
-    border-top: 7px solid ${({ theme }) => theme.COLORS.CHOCOLATE};
-    border-right: 6px solid transparent;
-    border-left: 6px solid transparent;
+    top: calc(${({ height }) => height} / 2 - ${calculateVwBasedOnFigma(2)});
+    right: ${calculateVwBasedOnFigma(14)};
+    border-top: ${calculateVwBasedOnFigma(7)} solid ${({ theme }) => theme.COLORS.CHOCOLATE};
+    border-right: ${calculateVwBasedOnFigma(6)} solid transparent;
+    border-left: ${calculateVwBasedOnFigma(6)} solid transparent;
   }
 `
 StyledSelectWrapper.defaultProps = {
-  height: '40px',
+  height: calculateVwBasedOnFigma(40),
 }
 const StyledSelect = styled.select<StyledSelectProps>`
   -webkit-appearance: none;
   appearance: none;
   width: ${({ width }) => width};
   height: ${({ height }) => height};
-  padding-left: 8px;
+  padding-left: ${calculateVwBasedOnFigma(8)};
   border: ${({ border }) => border};
   border-radius: ${({ borderRadius }) => borderRadius};
   background-color: ${({ backgroundColor }) => backgroundColor};
   color: ${({ color }) => color};
 `
 StyledSelect.defaultProps = {
-  width: 'min(33.33vw, 480px)',
-  height: '40px',
+  width: `min(33.33vw, ${calculateVwBasedOnFigma(480)})`,
+  height: calculateVwBasedOnFigma(40),
   border: `solid 1px ${theme.COLORS.CHOCOLATE}`,
   borderRadius: '2px',
   backgroundColor: convertIntoRGBA(theme.COLORS.WHITE, 0.7),

--- a/frontend/src/components/ui/form/SelectField.tsx
+++ b/frontend/src/components/ui/form/SelectField.tsx
@@ -115,6 +115,9 @@ const StyledSelect = styled.select<StyledSelectProps>`
   border-radius: ${({ borderRadius }) => borderRadius};
   background-color: ${({ backgroundColor }) => backgroundColor};
   color: ${({ color }) => color};
+  &::placeholder {
+    font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
+  }
 `
 StyledSelect.defaultProps = {
   width: `min(33.33vw, ${calculateVwBasedOnFigma(480)})`,

--- a/frontend/src/components/ui/header/AuthHeader.tsx
+++ b/frontend/src/components/ui/header/AuthHeader.tsx
@@ -2,13 +2,14 @@ import React, { FC } from 'react'
 import { theme } from 'styles/theme'
 import styled from 'styled-components'
 import { SimpleRoundedButton } from 'components/ui/button/SimpleRoundedButton'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 import { useNavigate } from 'react-router-dom'
 
 export const AuthHeader: FC = () => {
   const navigate = useNavigate()
   const commonButtonProps = {
-    width: '120px',
-    height: '40px',
+    width: calculateVwBasedOnFigma(120),
+    height: calculateVwBasedOnFigma(40),
     borderRadius: '2px',
   }
   const registerButtonProps = {
@@ -51,20 +52,20 @@ const StyledHeaderWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 28px;
+  padding: 0 ${calculateVwBasedOnFigma(28)};
   width: 100vw;
-  height: 70px;
+  height: ${calculateVwBasedOnFigma(70)};
   background-color: ${({ theme }) => theme.COLORS.MINE_SHAFT};
 `
 const StyledLogoWrapper = styled.div`
   object-fit: contain;
   width: 100%;
-  height: 43px;
+  height: ${calculateVwBasedOnFigma(43)};
 `
 const StyledButtonsWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 14px;
+  gap: ${calculateVwBasedOnFigma(14)};
   height: 100%;
 `

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -81,7 +81,7 @@ const StyledWrapper = styled.div`
   display: flex;
   justify-content: center;
   width: 100vw;
-  padding-top: ${({ theme }) => calculateVwBasedOnFigma(theme.HEADER_HEIGHT)};
+  padding-top: ${({ theme }) => theme.HEADER_HEIGHT};
   input {
     cursor: url('feather-pen.png') 10 124, pointer;
   }

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -81,7 +81,7 @@ const StyledWrapper = styled.div`
   display: flex;
   justify-content: center;
   width: 100vw;
-  padding-top: ${({ theme }) => theme.HEADER_HEIGHT};
+  padding-top: ${({ theme }) => calculateVwBasedOnFigma(theme.HEADER_HEIGHT)};
   input {
     cursor: url('feather-pen.png') 10 124, pointer;
   }

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -5,6 +5,7 @@ import { InputField } from 'components/ui/form/InputField'
 import { PasswordField } from 'components/ui/form/PasswordField'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 import { useNavigateUser } from 'hooks/useNavigateUser'
 import { useSignInForm } from 'hooks/useSignInForm'
 import { useTrySignIn } from 'hooks/useTrySignIn'
@@ -39,7 +40,7 @@ export const SignIn: FC = () => {
 
             <StyledSignInButton
               text="ログイン"
-              aspect={{ width: '120px', height: '32px' }}
+              aspect={{ width: calculateVwBasedOnFigma(120), height: calculateVwBasedOnFigma(32) }}
               outerBgColor={
                 isDisabled
                   ? convertIntoRGBA(theme.COLORS.ALTO, 0.55)
@@ -89,10 +90,10 @@ const StyledSignIn = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: max(50.69vw, 730px);
+  width: ${calculateVwBasedOnFigma(730)};
   height: 100%;
-  margin: 113px 0;
-  padding: 30px 0 46px;
+  margin: ${calculateVwBasedOnFigma(113)} 0;
+  padding: ${calculateVwBasedOnFigma(30)} 0 ${calculateVwBasedOnFigma(46)};
   background-image: url('sign-in-paper.png');
   background-size: 100% 100%;
 `
@@ -100,18 +101,18 @@ const StyledFormWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: min(33.333vw, 480px);
+  width: ${calculateVwBasedOnFigma(480)};
 `
 const StyledLogoImg = styled.img`
-  height: 170px;
+  height: ${calculateVwBasedOnFigma(170)};
 `
 const StyledParagraphWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 13px;
-  margin-top: 24px;
+  gap: ${calculateVwBasedOnFigma(13)};
+  margin-top: ${calculateVwBasedOnFigma(24)};
 `
 const StyledTextLineWrapper = styled.div`
   display: flex;

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -14,6 +14,7 @@ import { SelectField } from 'components/ui/form/SelectField'
 import { ItemInputField } from 'components/ui/form/ItemInputField'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 import styled from 'styled-components'
 import { theme } from 'styles/theme'
 
@@ -44,9 +45,18 @@ export const SignUp: FC = () => {
           <StyledH1>新規登録書</StyledH1>
           <StyledFormWrapper>
             <StyledImageInputField
-              margin={innerWidth <= 1210 ? '0 auto 24px auto' : '0 0 24px 0'}
+              margin={
+                innerWidth <= 1210
+                  ? `0 auto ${calculateVwBasedOnFigma(24)} auto`
+                  : `0 0 ${calculateVwBasedOnFigma(24)} 0`
+              }
             />
-            <StyledRightColumn margin={innerWidth <= 1210 ? '0 auto 24px auto' : '0 0 24px 0'}>
+            <StyledRightColumn
+              margin={
+                innerWidth <= 1210
+                  ? `0 auto ${calculateVwBasedOnFigma(24)} auto`
+                  : `0 0 ${calculateVwBasedOnFigma(24)} 0`
+              }>
               <InputField
                 label="冒険者"
                 registration={register('name', {
@@ -128,14 +138,20 @@ export const SignUp: FC = () => {
                 label="保有資格"
                 items={certifications}
                 setItems={setCertifications}
-                inputAspect={{ width: '400px', height: '40px' }}
+                inputAspect={{
+                  width: calculateVwBasedOnFigma(400),
+                  height: calculateVwBasedOnFigma(40),
+                }}
                 placeholder="保有資格を入力してください"
               />
               <StyledItemInputField
                 label="興味のあること"
                 items={interests}
                 setItems={setInterests}
-                inputAspect={{ width: '400px', height: '40px' }}
+                inputAspect={{
+                  width: calculateVwBasedOnFigma(400),
+                  height: calculateVwBasedOnFigma(40),
+                }}
                 placeholder="興味のあることを入力してください"
               />
 
@@ -147,7 +163,10 @@ export const SignUp: FC = () => {
 
               <StyledSignUpButton
                 text="登録"
-                aspect={{ width: '120px', height: '32px' }}
+                aspect={{
+                  width: calculateVwBasedOnFigma(120),
+                  height: calculateVwBasedOnFigma(32),
+                }}
                 outerBgColor={
                   isDisabled
                     ? convertIntoRGBA(theme.COLORS.ALTO, 0.55)
@@ -184,18 +203,18 @@ const StyledSignUp = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: max(58.33vw, 840px);
+  width: ${calculateVwBasedOnFigma(840)};
   height: 100%;
-  margin: 26px 0;
-  padding: 64px 0;
+  margin: ${calculateVwBasedOnFigma(26)} 0;
+  padding: ${calculateVwBasedOnFigma(64)} 0;
   background-image: url('contract-paper.png');
   background-size: 100% 100%;
 `
 const StyledLogoImg = styled.img`
-  height: 108px;
+  height: ${calculateVwBasedOnFigma(108)};
 `
 const StyledH1 = styled.h1`
-  margin: 33px 0;
+  margin: ${calculateVwBasedOnFigma(33)} 0;
   background: -webkit-linear-gradient(
     top,
     ${({ theme }) => theme.COLORS.TENN},
@@ -212,13 +231,13 @@ const StyledFormWrapper = styled.div`
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
-  width: min(49.02vw, 706px);
+  width: ${calculateVwBasedOnFigma(706)};
 `
 const StyledRightColumn = styled.div.attrs<{ margin: string }>(({ margin }) => ({
   margin,
 }))<{ margin: string }>`
   margin: ${({ margin }) => margin};
-  width: min(33.33vw, 480px);
+  width: ${calculateVwBasedOnFigma(480)};
 `
 const StyledImageInputField = styled(ImageInputField).attrs<{ margin: string }>(({ margin }) => ({
   margin,
@@ -226,7 +245,7 @@ const StyledImageInputField = styled(ImageInputField).attrs<{ margin: string }>(
   margin: ${({ margin }) => margin};
 `
 const StyledItemInputField = styled(ItemInputField)`
-  margin-bottom: 24px;
+  margin-bottom: ${calculateVwBasedOnFigma(24)};
 `
 const StyledBackground = styled.div`
   z-index: ${({ theme }) => theme.Z_INDEX.INDEX_MINUS_1};
@@ -240,7 +259,7 @@ const StyledBackground = styled.div`
   background-position: 50% 100%;
 `
 const StyledTerms = styled.p`
-  margin: 24px 0;
+  margin: ${calculateVwBasedOnFigma(24)} 0;
   font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
   font-weight: ${({ theme }) => theme.FONT_WEIGHTS.LIGHT};
 `

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,7 +1,8 @@
+import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 import 'styled-components'
 
 export const theme = {
-  HEADER_HEIGHT: '70px',
+  HEADER_HEIGHT: calculateVwBasedOnFigma('70px'),
   Z_INDEX: {
     INDEX_MINUS_1: -1,
     INDEX_1: 1,
@@ -9,22 +10,22 @@ export const theme = {
     HEADER: 100,
   },
   FONT_SIZES: {
-    SIZE_10: '10px',
-    SIZE_12: '12px',
-    SIZE_14: '14px',
-    SIZE_16: '16px',
-    SIZE_18: '18px',
-    SIZE_20: '20px',
-    SIZE_22: '22px',
-    SIZE_24: '24px',
-    SIZE_28: '28px',
-    SIZE_32: '32px',
-    SIZE_36: '36px',
-    SIZE_40: '40px',
-    SIZE_48: '48px',
-    SIZE_52: '52px',
-    SIZE_56: '56px',
-    SIZE_60: '60px',
+    SIZE_10: calculateVwBasedOnFigma('10px'),
+    SIZE_12: calculateVwBasedOnFigma('12px'),
+    SIZE_14: calculateVwBasedOnFigma('14px'),
+    SIZE_16: calculateVwBasedOnFigma('16px'),
+    SIZE_18: calculateVwBasedOnFigma('18px'),
+    SIZE_20: calculateVwBasedOnFigma('20px'),
+    SIZE_22: calculateVwBasedOnFigma('22px'),
+    SIZE_24: calculateVwBasedOnFigma('24px'),
+    SIZE_28: calculateVwBasedOnFigma('28px'),
+    SIZE_32: calculateVwBasedOnFigma('32px'),
+    SIZE_36: calculateVwBasedOnFigma('36px'),
+    SIZE_40: calculateVwBasedOnFigma('40px'),
+    SIZE_48: calculateVwBasedOnFigma('48px'),
+    SIZE_52: calculateVwBasedOnFigma('52px'),
+    SIZE_56: calculateVwBasedOnFigma('56px'),
+    SIZE_60: calculateVwBasedOnFigma('60px'),
   },
   FONT_WEIGHTS: {
     LIGHT: 300,

--- a/frontend/src/utils/calculateVwBasedOnFigma.ts
+++ b/frontend/src/utils/calculateVwBasedOnFigma.ts
@@ -1,4 +1,4 @@
-export const calculateVwFromStandardSize = (px: number) => {
+export const calculateVwBasedOnFigma = (px: number) => {
   const FIGMA_WIDTH_PX = 1440
   return `${(px / FIGMA_WIDTH_PX) * 100}vw`
 }

--- a/frontend/src/utils/calculateVwBasedOnFigma.ts
+++ b/frontend/src/utils/calculateVwBasedOnFigma.ts
@@ -1,4 +1,8 @@
-export const calculateVwBasedOnFigma = (px: number) => {
+type pxStr = `${number}px`
+
+export const calculateVwBasedOnFigma = (px: number | pxStr) => {
   const FIGMA_WIDTH_PX = 1440
-  return `${(px / FIGMA_WIDTH_PX) * 100}vw`
+  const numPx = typeof px === 'string' ? Number(px.replace('px', '')) : px
+
+  return `${(numPx / FIGMA_WIDTH_PX) * 100}vw`
 }

--- a/frontend/src/utils/calculateVwFromStandardSize.ts
+++ b/frontend/src/utils/calculateVwFromStandardSize.ts
@@ -1,0 +1,4 @@
+export const calculateVwFromStandardSize = (px: number) => {
+  const FIGMA_WIDTH_PX = 1440
+  return `${(px / FIGMA_WIDTH_PX) * 100}vw`
+}


### PR DESCRIPTION
## 実装の概要
- px指定していたものを**全てvwにした**
  - `calculateVwBasedOnFigma`というメソッドを作成し、Figmaで設定されているpxを入力するとvwに変換して出力してくれるようにした
  - この関数を至るところで使い強制的にレスポンシブにした
  - border や box-shadows に関しては固定値でいいと思ったのでvwにはしていない

Trello #65 
Closes #65 

![responsive-min](https://user-images.githubusercontent.com/47961006/143284023-d7b5174d-a88f-4c45-85dc-05cd752b2c2c.gif)

## 目的
- ディスプレイでもPC上でもFigmaの画面設計通りのデザインになるようにする

## レビューして欲しいところ(不安に思っていること)
- `theme.ts` の font-size もvwにしている
  - 今回はPC以外に対応する予定はないので、font-sizeがvwでも問題ないと判断した

## 今後のタスク
- #67
