### PR TITLE
プロフィール画像のドット化を無効にする

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,19 @@
 import React, { FC } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { AppRoutes } from 'routes/AppRoutes'
+import { AppProvider } from 'providers/AppProvider'
+import { GlobalStyle } from 'styles/globalStyle'
+import { ToastContainer } from 'react-toastify'
 
 const App: FC = () => {
   return (
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
+    <AppProvider>
+      <GlobalStyle />
+      <ToastContainer />
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </AppProvider>
   )
 }
 

--- a/frontend/src/components/ui/form/ImageInputField.tsx
+++ b/frontend/src/components/ui/form/ImageInputField.tsx
@@ -7,7 +7,7 @@ import { calculateVwBasedOnFigma } from 'utils/calculateVwBasedOnFigma'
 
 type Props = {
   className?: string
-  dottedImage: string
+  image: string
   defaultSrc: string
   handleUploadImg: (e: React.ChangeEvent<HTMLInputElement>) => void
   initializeUploadImg: () => void
@@ -15,7 +15,7 @@ type Props = {
 
 export const ImageInputField: FC<Props> = ({
   className,
-  dottedImage,
+  image,
   defaultSrc,
   handleUploadImg,
   initializeUploadImg,
@@ -29,9 +29,9 @@ export const ImageInputField: FC<Props> = ({
         プロフィール画像
         <StyledImageWrapper>
           <StyledImage
-            src={dottedImage}
+            src={image}
             alt="プロフィール画像"
-            padding={dottedImage === defaultSrc ? calculateVwBasedOnFigma(40) : '0px'}
+            defaultSrc={image === defaultSrc ? true : false}
           />
         </StyledImageWrapper>
         <StyledDisappearedInput
@@ -77,11 +77,11 @@ const StyledImageWrapper = styled.div`
   border-radius: 2px;
   background-color: ${({ theme }) => theme.COLORS.WHITE};
 `
-const StyledImage = styled.img<{ padding: string }>`
+const StyledImage = styled.img<{ defaultSrc: boolean }>`
   aspect-ratio: 1 / 1;
-  object-fit: contain;
+  object-fit: ${({ defaultSrc }) => (defaultSrc ? 'contain' : 'cover')};
   width: 100%;
-  padding: ${({ padding }) => padding};
+  padding: ${({ defaultSrc }) => (defaultSrc ? calculateVwBasedOnFigma(40) : '0px')};
 `
 const StyledDisappearedInput = styled.input`
   display: none;

--- a/frontend/src/hooks/useDataUrlToBlob.ts
+++ b/frontend/src/hooks/useDataUrlToBlob.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+import Pixelize from 'utils/pixelize'
+
+type UseDataUrlToBlobReturn = { blobData: Blob | null }
+
+/**
+ * blob:urlからBlobへ変換
+ *
+ * @param {string} url
+ * @return {Blob | null} fileData
+ */
+export const useDataUrlToBlob = (url: string | undefined): UseDataUrlToBlobReturn => {
+  const [dataUrl, setDataUrl] = useState<string | undefined>()
+  const [blobData, setBlobData] = useState<Blob | null>(null)
+
+  useEffect(() => {
+    setDataUrl(url)
+    if (!dataUrl) return
+    setBlobData(Pixelize.dataURLtoBlob(dataUrl))
+  }, [dataUrl, url])
+
+  return { blobData }
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,18 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
-import { AppProvider } from 'providers/AppProvider'
-import { GlobalStyle } from 'styles/globalStyle'
-import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 ReactDOM.render(
   <React.StrictMode>
-    <AppProvider>
-      <GlobalStyle />
-      <ToastContainer />
-      <App />
-    </AppProvider>
+    <App />
   </React.StrictMode>,
   document.getElementById('root'),
 )

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -7,7 +7,7 @@ import { useTrySignUp } from 'hooks/useTrySignUp'
 import { useSignUpForm } from 'hooks/useSignUpForm'
 import { useWatchInnerAspect } from 'hooks/useWatchInnerAspect'
 import { useImageResize } from 'hooks/useImageResize'
-import { useConvertToDottedImage } from 'hooks/useConvertToDottedImage'
+import { useDataUrlToBlob } from 'hooks/useDataUrlToBlob'
 import { useBlobToFile } from 'hooks/useBlobToFile'
 import { AuthHeader } from 'components/ui/header/AuthHeader'
 import { ImageInputField } from 'components/ui/form/ImageInputField'
@@ -27,11 +27,11 @@ export const SignUp: FC = () => {
   const [interests, setInterests] = useState<string[]>([])
   const { canvasContext, imageUrl, initializeUploadImg, handleUploadImg } = useImageResize(
     SIGN_UP_CAMERA,
-    60,
+    300,
   )
-  const { dottedImage } = useConvertToDottedImage(imageUrl, 50, canvasContext)
+  const { blobData } = useDataUrlToBlob(canvasContext?.canvas.toDataURL())
   const { innerWidth } = useWatchInnerAspect()
-  const { fileData } = useBlobToFile(dottedImage.blob)
+  const { fileData } = useBlobToFile(blobData)
   const trySignUp = useTrySignUp({ ...getValues(), certifications, interests, fileData })
 
   const occupationOptions: Record<'value' | 'item', string>[] = occupationList.map(v => {
@@ -54,7 +54,7 @@ export const SignUp: FC = () => {
           <StyledH1>新規登録書</StyledH1>
           <StyledFormWrapper>
             <StyledImageInputField
-              dottedImage={dottedImage.URLScheme}
+              dottedImage={imageUrl}
               defaultSrc={SIGN_UP_CAMERA}
               initializeUploadImg={initializeUploadImg}
               handleUploadImg={handleUploadImg}

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -54,7 +54,7 @@ export const SignUp: FC = () => {
           <StyledH1>新規登録書</StyledH1>
           <StyledFormWrapper>
             <StyledImageInputField
-              dottedImage={imageUrl}
+              image={imageUrl}
               defaultSrc={SIGN_UP_CAMERA}
               initializeUploadImg={initializeUploadImg}
               handleUploadImg={handleUploadImg}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { FC } from 'react'
 import { useRoutes } from 'react-router-dom'
 import { useAuthContext } from 'providers/AuthProvider'
 import { NotFound } from 'pages/notFound/NotFound'
 import { protectedRoutes } from './Protected'
 import { publicRoutes } from './Public'
 
-export const AppRoutes = () => {
+export const AppRoutes: FC = () => {
   const { currentUser } = useAuthContext()
   const commonRoutes = [{ path: '*', element: <NotFound /> }]
   const routes = currentUser ? protectedRoutes : publicRoutes

--- a/frontend/src/routes/Protected.tsx
+++ b/frontend/src/routes/Protected.tsx
@@ -11,20 +11,18 @@ const { ProjectDetail } = lazyImport(
 const { MyPage } = lazyImport(() => import('pages/mypage/MyPage'), 'MyPage')
 const { Invitation } = lazyImport(() => import('pages/invitation'), 'Invitation')
 
-const App: FC = () => {
+const ProtectedRoute: FC = () => {
   return (
-    <>
-      <Suspense fallback={<Loading />}>
-        <Outlet />
-      </Suspense>
-    </>
+    <Suspense fallback={<Loading />}>
+      <Outlet />
+    </Suspense>
   )
 }
 
 export const protectedRoutes = [
   {
     path: '/',
-    element: <App />,
+    element: <ProtectedRoute />,
     children: [
       { path: '/', element: <ProjectList /> },
       { path: '/projects/:id', element: <ProjectDetail /> },


### PR DESCRIPTION
## 実装の概要
- ドット絵化を無しにした（hookで切り分けたから戻すときは簡単）
- components/ImageInputField の object-fitとpaddingを修正
<!-- 概要を入力 -->

Trello #89 
Closes #89 

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
