### PR TITLE
feat/hr-mutation

### DIFF
--- a/api/src/companies/companies.module.ts
+++ b/api/src/companies/companies.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Company } from './company';
+import { CompaniesService } from './companies.service';
+import { CompaniesResolver } from './companies.resolver';
 @Module({
   imports: [TypeOrmModule.forFeature([Company])],
+  providers: [CompaniesService, CompaniesResolver],
+  exports: [CompaniesService],
 })
 export class CompaniesModule {}

--- a/api/src/companies/companies.module.ts
+++ b/api/src/companies/companies.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Company } from './company';
 import { CompaniesService } from './companies.service';
 import { CompaniesResolver } from './companies.resolver';
+
 @Module({
   imports: [TypeOrmModule.forFeature([Company])],
   providers: [CompaniesService, CompaniesResolver],

--- a/api/src/companies/companies.resolver.ts
+++ b/api/src/companies/companies.resolver.ts
@@ -1,0 +1,31 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { CompaniesService } from './companies.service';
+import { Company } from './company';
+import { PubSub } from 'graphql-subscriptions';
+import { NewCompanyInput } from './dto/newCompany.input';
+import { NotFoundException } from '@nestjs/common';
+@Resolver((of) => Company)
+export class CompaniesResolver {
+  private pubSub: PubSub;
+  constructor(private companiesService: CompaniesService) {
+    this.pubSub = new PubSub();
+  }
+
+  @Query(() => Company)
+  async getCompany(@Args({ name: 'uid' }) uid: string) {
+    const company = await this.companiesService.getCompany(uid);
+    if (!company) {
+      throw new NotFoundException();
+    }
+    return company;
+  }
+
+  @Mutation(() => Company)
+  public async addCompany(
+    @Args({ name: 'newCompany' }) newCompany: NewCompanyInput,
+  ) {
+    return await this.companiesService.addCompany(newCompany).catch((err) => {
+      throw err;
+    });
+  }
+}

--- a/api/src/companies/companies.resolver.ts
+++ b/api/src/companies/companies.resolver.ts
@@ -4,7 +4,8 @@ import { Company } from './company';
 import { PubSub } from 'graphql-subscriptions';
 import { NewCompanyInput } from './dto/newCompany.input';
 import { NotFoundException } from '@nestjs/common';
-@Resolver((of) => Company)
+
+@Resolver(() => Company)
 export class CompaniesResolver {
   private pubSub: PubSub;
   constructor(private companiesService: CompaniesService) {
@@ -17,6 +18,7 @@ export class CompaniesResolver {
     if (!company) {
       throw new NotFoundException();
     }
+
     return company;
   }
 

--- a/api/src/companies/companies.service.ts
+++ b/api/src/companies/companies.service.ts
@@ -1,0 +1,34 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Company } from './company';
+import { NewCompanyInput } from './dto/newCompany.input';
+@Injectable()
+export class CompaniesService {
+  constructor(
+    @InjectRepository(Company)
+    private companyRepository: Repository<Company>,
+  ) {}
+
+  getCompany(uid: string): Promise<Company> {
+    const company = this.companyRepository.findOne(uid);
+    if (!company) throw new NotFoundException();
+    return company;
+  }
+
+  async addCompany(newCompany: NewCompanyInput): Promise<Company> {
+    const company = this.companyRepository.create({
+      uid: newCompany.uid,
+      name: newCompany.name,
+    });
+    await this.companyRepository.save(company).catch((err) => {
+      throw err;
+    });
+
+    return company;
+  }
+}

--- a/api/src/companies/companies.service.ts
+++ b/api/src/companies/companies.service.ts
@@ -1,12 +1,9 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Company } from './company';
 import { NewCompanyInput } from './dto/newCompany.input';
+
 @Injectable()
 export class CompaniesService {
   constructor(
@@ -17,6 +14,7 @@ export class CompaniesService {
   getCompany(uid: string): Promise<Company> {
     const company = this.companyRepository.findOne(uid);
     if (!company) throw new NotFoundException();
+
     return company;
   }
 

--- a/api/src/companies/company.ts
+++ b/api/src/companies/company.ts
@@ -1,11 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 
 @Entity('companies')
 @ObjectType()
 export class Company {
   //uid
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   @Field()
   uid: string;
 

--- a/api/src/companies/dto/newCompany.input.ts
+++ b/api/src/companies/dto/newCompany.input.ts
@@ -1,10 +1,13 @@
 import { Field, InputType } from '@nestjs/graphql';
-import { MaxLength, IsNotEmpty, IsString } from 'class-validator';
+import { MaxLength, IsString } from 'class-validator';
 
 @InputType()
 export class NewCompanyInput {
   @Field()
-  @IsNotEmpty()
+  @IsString()
+  uid: string;
+
+  @Field()
   @IsString()
   @MaxLength(50)
   name: string;

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -161,12 +161,19 @@ type User {
   deleted_at: DateTime!
 }
 
+type Company {
+  uid: String!
+  name: String!
+}
+
 type Query {
   allUsers: [User!]!
   user(id: String!): User!
+  findHrUsers(company: String!): [User!]!
   certifications(user_ids: [String!]!): [Certification!]!
   allInterests: [Interest!]!
   interestsByUserIds(user_ids: [String!]!): [Interest!]!
+  getCompany(uid: String!): Company!
   getProjectById(id: Float!): Project!
   invitation(projectId: String!, userId: String!): Invitation!
   invitations(userId: String!): [Invitation!]!
@@ -177,8 +184,10 @@ type Mutation {
   addUser(newCertification: NewCertificationClientInput!, newInterest: NewInterestClientInput!, newUser: NewUserInput!): User!
   searchSameCompanyUsers(conditionSearchUser: SearchUserInput!): [User!]!
   updateOnlineFlag(isOnline: Boolean!, id: String!): User!
+  updateMemo(memo: String!, id: String!): User!
   addCertification(newCertification: NewCertificationInput!): Certification!
   addInterest(newInterest: NewInterestInput!): Interest!
+  addCompany(newCompany: NewCompanyInput!): Company!
   createProject(selectUser: SelectUser!, newProject: NewProjectInput!): Project!
   joinProject(projectId: String!, userId: String!, invitationId: String!): Group!
   createInvitation(projectId: String!, userId: String!): Invitation!
@@ -229,6 +238,11 @@ input NewCertificationInput {
 input NewInterestInput {
   context: String!
   user_id: String!
+}
+
+input NewCompanyInput {
+  uid: String!
+  name: String!
 }
 
 input SelectUser {

--- a/api/src/users/users.resolver.ts
+++ b/api/src/users/users.resolver.ts
@@ -31,6 +31,15 @@ export class UsersResolver {
     return user;
   }
 
+  @Query(() => [User])
+  public async findHrUsers(
+    @Args({ name: 'company' }) company: string,
+  ): Promise<User[]> {
+    return this.usersService.getHrAllUsers(company).catch((err) => {
+      throw err;
+    });
+  }
+
   @Mutation(() => User)
   public async addUser(
     @Args('newUser') newUser: NewUserInput,
@@ -66,6 +75,17 @@ export class UsersResolver {
   ) {
     const user = await this.usersService.updateOnlineFlag(id, isOnline);
     if (!user) throw new NotFoundException({ id, isOnline });
+
+    return user;
+  }
+
+  @Mutation(() => User)
+  public async updateMemo(
+    @Args({ name: 'id' }) id: string,
+    @Args({ name: 'memo' }) memo: string,
+  ) {
+    const user = await this.usersService.updateMemo(id, memo);
+    if (!user) throw new NotFoundException({ id, memo });
 
     return user;
   }

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -42,6 +42,18 @@ export class UsersService {
     return user;
   }
 
+  getHrAllUsers(company: string): Promise<User[]> {
+    const users = this.usersRepository.find({
+      relations: ['interests', 'certifications'],
+      where: {
+        company: company,
+      },
+    });
+    if (!users) throw new NotFoundException();
+
+    return users;
+  }
+
   async create({
     newUser,
     newInterest,
@@ -104,6 +116,19 @@ export class UsersService {
     if (!user) throw new NotFoundException();
 
     user.online_flg = isOnline;
+    await this.usersRepository.save(user).catch((err) => {
+      new InternalServerErrorException();
+    });
+
+    return user;
+  }
+
+  async updateMemo(id: string, memo: string) {
+    const user = await this.usersRepository.findOne(id);
+
+    if (!user) throw new NotFoundException();
+
+    user.memo = memo;
     await this.usersRepository.save(user).catch((err) => {
       new InternalServerErrorException();
     });


### PR DESCRIPTION
## 実装の概要
必要なquery・mutaition
企業名登録(人事ユーザ)
addCompany
ログイン(企業ユーザ(uid・会社名)取得)(query)
getCompany
社員ユーザ一覧取得(query)
findHrUsers
社員メモ(addMutation)
updateMemo
