### PR TITLE
feat: 小さいサイズとタグスタイルを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ up:
 	docker compose up
 down:
 	docker compose down
+restart:
+	@make down
+	@make up
 ps:
 	docker compose ps
 build:

--- a/frontend/public/svg/tag-triangle-small_background.svg
+++ b/frontend/public/svg/tag-triangle-small_background.svg
@@ -1,0 +1,13 @@
+<svg width="15" height="24" viewBox="0 0 15 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.9196 0.557226C12.292 0.199668 12.7883 0 13.3046 0H15V24H13.3046C12.7883 24 12.292 23.8003 11.9196 23.4428L1.50289 13.4428C0.682976 12.6557 0.682975 11.3443 1.50289 10.5572L11.9196 0.557226Z" fill="#F5EDE5"/>
+<path d="M11.9196 0.557226C12.292 0.199668 12.7883 0 13.3046 0H15V24H13.3046C12.7883 24 12.292 23.8003 11.9196 23.4428L1.50289 13.4428C0.682976 12.6557 0.682975 11.3443 1.50289 10.5572L11.9196 0.557226Z" fill="url(#paint0_linear_3431_46959)" fill-opacity="0.07"/>
+<circle cx="10" cy="12" r="2" fill="#665545" fill-opacity="0.78"/>
+<defs>
+<linearGradient id="paint0_linear_3431_46959" x1="7.5" y1="0" x2="7.5" y2="24" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="0.046875" stop-opacity="0"/>
+<stop offset="0.578125" stop-opacity="0"/>
+<stop offset="1"/>
+</linearGradient>
+</defs>
+</svg>

--- a/frontend/src/components/models/myPage/MyPageTags.tsx
+++ b/frontend/src/components/models/myPage/MyPageTags.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import logger from 'utils/debugger/logger'
-import { Tag, TAG_TYPE } from '../../ui/tag/Tag'
+import { Tag, TAG_TYPE } from 'components/ui/tag/Tag'
 
 type Props = {
   className?: string

--- a/frontend/src/components/models/myPage/MyPageTags.tsx
+++ b/frontend/src/components/models/myPage/MyPageTags.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import logger from 'utils/debugger/logger'
-import { Tag } from '../../ui/tag/Tag'
+import { Tag, TAG_TYPE } from '../../ui/tag/Tag'
 
 type Props = {
   className?: string
@@ -31,7 +31,7 @@ export const MyPageTags: FC<Props> = ({ className, interests, certifications }) 
 
         <StyledMyPageTagWrapper>
           {interests.map((interest, index) => (
-            <Tag name={interest.context} key={index} />
+            <Tag name={interest.context} key={index} tagType={TAG_TYPE.NORMAL} />
           ))}
         </StyledMyPageTagWrapper>
 
@@ -42,7 +42,7 @@ export const MyPageTags: FC<Props> = ({ className, interests, certifications }) 
 
         <StyledMyPageTagWrapper>
           {certifications.map((certification, index) => (
-            <Tag name={certification.name} key={index} />
+            <Tag name={certification.name} key={index} tagType={TAG_TYPE.NORMAL} />
           ))}
         </StyledMyPageTagWrapper>
       </StyledMyPageTagsScroll>

--- a/frontend/src/components/ui/tag/Tag.tsx
+++ b/frontend/src/components/ui/tag/Tag.tsx
@@ -25,7 +25,9 @@ export const Tag: FC<Props> = ({ className, name, onClick, tagType }) => {
       <StyledTagTriangle tagType={tagType} />
       <StyledTag tagType={tagType}>
         <p>{name}</p>
-        {onClick && <StyledCrossButton color={theme.COLORS.CHOCOLATE} onClick={onClick} />}
+        {onClick && (
+          <StyledCrossButton tagType={tagType} color={theme.COLORS.CHOCOLATE} onClick={onClick} />
+        )}
       </StyledTag>
     </StyledTagContainer>
   )
@@ -97,12 +99,23 @@ const StyledTag = styled.div<{ tagType: TAG_TYPE }>`
 `
 
 // TODO: 罰ボタンありのタグデザインが上がってきたら修正しないと大きさが変わる
-const StyledCrossButton = styled(CrossButton)`
+const StyledCrossButton = styled(CrossButton)<{ tagType: TAG_TYPE }>`
   height: 100%;
-  padding: ${calculateMinSizeBasedOnFigmaWidth(10)} ${calculateMinSizeBasedOnFigmaWidth(7)}
-    ${calculateMinSizeBasedOnFigmaWidth(10)} 0;
   svg {
     width: ${calculateMinSizeBasedOnFigmaWidth(8)};
     height: ${calculateMinSizeBasedOnFigmaWidth(8)};
   }
+
+  ${({ tagType }) => css`
+    ${tagType === TAG_TYPE.NORMAL &&
+    css`
+      padding: ${calculateMinSizeBasedOnFigmaWidth(10)} ${calculateMinSizeBasedOnFigmaWidth(7)}
+        ${calculateMinSizeBasedOnFigmaWidth(10)} 0;
+    `}
+
+    ${tagType === TAG_TYPE.SMALL &&
+    css`
+      padding-right: ${calculateMinSizeBasedOnFigmaWidth(6)};
+    `}
+  `}
 `

--- a/frontend/src/components/ui/tag/Tag.tsx
+++ b/frontend/src/components/ui/tag/Tag.tsx
@@ -25,7 +25,7 @@ export const Tag: FC<Props> = ({ className, name, onClick, tagType }) => {
       <StyledTagTriangle tagType={tagType} />
       <StyledTag tagType={tagType}>
         <p>{name}</p>
-        {onClick && (
+        {!!onClick && (
           <StyledCrossButton tagType={tagType} color={theme.COLORS.CHOCOLATE} onClick={onClick} />
         )}
       </StyledTag>
@@ -98,7 +98,6 @@ const StyledTag = styled.div<{ tagType: TAG_TYPE }>`
   `}
 `
 
-// TODO: 罰ボタンありのタグデザインが上がってきたら修正しないと大きさが変わる
 const StyledCrossButton = styled(CrossButton)<{ tagType: TAG_TYPE }>`
   height: 100%;
   svg {

--- a/frontend/src/components/ui/tag/Tag.tsx
+++ b/frontend/src/components/ui/tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -8,21 +8,22 @@ type Props = {
   className?: string
   name: string
   onClick?: () => void
+  tagType: TAG_TYPE
 }
 
-export const Tag: FC<Props> = ({ className, name, onClick }) => {
-  const ref = useRef<HTMLDivElement>(null)
-  const [refHeight, setRefHeight] = useState(0)
+// TODO: 今後、もしlargeサイズが追加された時のためにlargeも置いとく
+export const TAG_TYPE = {
+  LARGE: 'large',
+  NORMAL: 'normal',
+  SMALL: 'small',
+} as const
+export type TAG_TYPE = typeof TAG_TYPE[keyof typeof TAG_TYPE]
 
-  useEffect(() => {
-    if (!ref.current) return
-    setRefHeight(ref.current.clientHeight)
-  }, [ref])
-
+export const Tag: FC<Props> = ({ className, name, onClick, tagType }) => {
   return (
     <StyledTagContainer className={className}>
-      <StyledTagTriangle refHeight={refHeight} />
-      <StyledTag ref={ref}>
+      <StyledTagTriangle tagType={tagType} />
+      <StyledTag tagType={tagType}>
         <p>{name}</p>
         {onClick && <StyledCrossButton color={theme.COLORS.CHOCOLATE} onClick={onClick} />}
       </StyledTag>
@@ -35,24 +36,29 @@ const StyledTagContainer = styled.div`
   align-items: center;
 `
 
-const StyledTagTriangle = styled.div<{ refHeight?: number }>`
-  width: ${calculateMinSizeBasedOnFigmaWidth(18)};
-  height: ${calculateMinSizeBasedOnFigmaWidth(32)};
-  ${({ refHeight }) =>
-    refHeight &&
+const StyledTagTriangle = styled.div<{ tagType: TAG_TYPE }>`
+  ${({ tagType }) => css`
+    ${tagType === TAG_TYPE.NORMAL &&
     css`
-      height: ${calculateMinSizeBasedOnFigmaWidth(refHeight)};
+      width: ${calculateMinSizeBasedOnFigmaWidth(18)};
+      height: ${calculateMinSizeBasedOnFigmaWidth(32)};
+      background: url('/svg/tag-triangle_background.svg');
     `}
 
-  background: url('/svg/tag-triangle_background.svg');
+    ${tagType === TAG_TYPE.SMALL &&
+    css`
+      width: ${calculateMinSizeBasedOnFigmaWidth(15)};
+      height: ${calculateMinSizeBasedOnFigmaWidth(24)};
+      background: url('/svg/tag-triangle-small_background.svg');
+    `}
+  `}
+
   background-repeat: no-repeat;
   background-size: cover;
 `
 
 // BUG: ウィンドウが小さすぎるとリピートした画像の隙間が見える
-const StyledTag = styled.div`
-  min-width: ${calculateMinSizeBasedOnFigmaWidth(16)};
-  min-height: ${calculateMinSizeBasedOnFigmaWidth(32)};
+const StyledTag = styled.div<{ tagType: TAG_TYPE }>`
   background: url('/svg/tag_background.svg');
   background-repeat: repeat-x;
   background-size: contain;
@@ -60,11 +66,37 @@ const StyledTag = styled.div`
   align-items: center;
 
   p {
-    font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
-    margin: 0 ${calculateMinSizeBasedOnFigmaWidth(7)};
+    font-weight: ${({ theme }) => theme.FONT_WEIGHTS.BOLD};
   }
+
+  ${({ tagType }) => css`
+    ${tagType === TAG_TYPE.NORMAL &&
+    css`
+      min-width: ${calculateMinSizeBasedOnFigmaWidth(16)};
+      min-height: ${calculateMinSizeBasedOnFigmaWidth(32)};
+
+      p {
+        font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
+        margin-left: ${calculateMinSizeBasedOnFigmaWidth(6)};
+        margin-right: ${calculateMinSizeBasedOnFigmaWidth(8)};
+      }
+    `}
+
+    ${tagType === TAG_TYPE.SMALL &&
+    css`
+      min-width: ${calculateMinSizeBasedOnFigmaWidth(15)};
+      min-height: ${calculateMinSizeBasedOnFigmaWidth(24)};
+
+      p {
+        font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_12};
+        margin-left: ${calculateMinSizeBasedOnFigmaWidth(4)};
+        margin-right: ${calculateMinSizeBasedOnFigmaWidth(6)};
+      }
+    `}
+  `}
 `
 
+// TODO: 罰ボタンありのタグデザインが上がってきたら修正しないと大きさが変わる
 const StyledCrossButton = styled(CrossButton)`
   height: 100%;
   padding: ${calculateMinSizeBasedOnFigmaWidth(10)} ${calculateMinSizeBasedOnFigmaWidth(7)}


### PR DESCRIPTION
## 実装の概要
タグが他の画面では小さいので小さいサイズのスタイルを適用
```
TAG_TYPE,NORMAL ← 普通のサイズ
TAG_TYPE.SMALL ← 小さいサイズ
```

## 目的
スタイルを分けるため

## レビューして欲しいところ

## 不安に思っていること
バツボタンのデザインが見つけられず、現状だとバツボタンが出現したらタグが少し大きくなる

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
