### PR TITLE
fix: タスクの作成、更新時のデータにcompleted_flgを追加

### DIFF
--- a/frontend/src/hooks/useTaskCreateForm.ts
+++ b/frontend/src/hooks/useTaskCreateForm.ts
@@ -101,6 +101,7 @@ export const useTaskCreateForm: UseTaskCreateForm<FormInputs> = ({ verticalSort 
           end_date: date,
           project_id: String(projectId),
           list_id: '1',
+          completed_flg: false,
         },
       },
     })

--- a/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectList/projectDetail/ProjectDetail.tsx
@@ -357,12 +357,14 @@ export const ProjectDetail: FC = () => {
       return list
     })
 
+    //TODO: 完了にカードが移動したらcompleted_flgをtrueにする処理を書く必要あり
     const updateTasks = sortListCopy.map(list => {
       return list.tasks.map((task, taskIndex) => {
         return {
           id: task.id,
           list_id: list.id,
           vertical_sort: taskIndex,
+          completed_flg: false,
         }
       })
     })


### PR DESCRIPTION
## 実装の概要
タスクの作成、更新時にcompleted_flgがないのでエラーが起きていたので修正した

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
