### PR TITLE
fix: タスク追加時のタスクIDが固定だったので修正

### DIFF
--- a/api/src/tasks/tasks.service.ts
+++ b/api/src/tasks/tasks.service.ts
@@ -59,7 +59,11 @@ export class TasksService {
     const project = await this.projectRepository.findOne(newTask.project_id);
     if (!project) throw new NotFoundException();
 
-    const list = await this.listRepository.findOne(newTask.list_id);
+    const list = await this.listRepository.findOne({
+      where: {
+        list_id: newTask.list_id,
+      },
+    });
     if (!list) throw new NotFoundException();
 
     const task = this.taskRepository.create({

--- a/frontend/src/components/models/task/TaskColumn.tsx
+++ b/frontend/src/components/models/task/TaskColumn.tsx
@@ -124,6 +124,7 @@ export const TaskColumn: FC<Props> = ({ id, list_id, title, tasks, listIndex, li
                         shouldShow={shouldShowModal}
                         setShouldShow={setShouldShowModal}
                         verticalSort={tasks.length}
+                        list_id={list_id}
                       />
                     </>
                   )}

--- a/frontend/src/components/models/task/TaskCreateModal.tsx
+++ b/frontend/src/components/models/task/TaskCreateModal.tsx
@@ -26,6 +26,7 @@ type Props = {
   setShouldShow: Dispatch<SetStateAction<boolean>>
   className?: string
   verticalSort: number
+  list_id: string
 }
 
 export const TaskCreateModal: FC<Props> = ({
@@ -33,10 +34,12 @@ export const TaskCreateModal: FC<Props> = ({
   setShouldShow,
   className,
   verticalSort,
+  list_id,
 }) => {
   const { handleAddTask, isDisabled, register, errors, setStatus, setUserDatas } =
     useTaskCreateForm({
       verticalSort,
+      list_id,
     })
 
   return (

--- a/frontend/src/hooks/useTaskCreateForm.ts
+++ b/frontend/src/hooks/useTaskCreateForm.ts
@@ -22,7 +22,10 @@ type UseTaskCreateFormReturn<T> = {
   setUserDatas: Dispatch<SetStateAction<UserDatas>>
 }
 
-type UseTaskCreateForm<T> = (args: { verticalSort: number }) => UseTaskCreateFormReturn<T>
+type UseTaskCreateForm<T> = (args: {
+  verticalSort: number
+  list_id: string
+}) => UseTaskCreateFormReturn<T>
 
 /**
  * タスク追加処理の初期設定を行う
@@ -35,7 +38,7 @@ type UseTaskCreateForm<T> = (args: { verticalSort: number }) => UseTaskCreateFor
  *  trigger
  *  } - react-hook-fromの公式ページを参照
  */
-export const useTaskCreateForm: UseTaskCreateForm<FormInputs> = ({ verticalSort }) => {
+export const useTaskCreateForm: UseTaskCreateForm<FormInputs> = ({ verticalSort, list_id }) => {
   const { id: projectId } = useParams()
   const {
     register,
@@ -100,7 +103,7 @@ export const useTaskCreateForm: UseTaskCreateForm<FormInputs> = ({ verticalSort 
           vertical_sort: verticalSort,
           end_date: date,
           project_id: String(projectId),
-          list_id: '1',
+          list_id: list_id,
           completed_flg: false,
         },
       },


### PR DESCRIPTION
## 実装の概要
タスク追加時のlist_idが`1`で固定されてたのでlist_idがプロジェクトごとに追加できるようにした

Trello #150
Closes #150

## 目的
現状だと、全てのプロジェクトで扱えなかったため

## レビューして欲しいところ
編集したフォイル

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
