### PR TITLE
test: フォントのチラつきをGoogle fontsで直せる

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,11 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Yanone+Kaffeesatz:wght@200;300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Yrsa:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@100;300;400;500;700;800;900&family=Yanone+Kaffeesatz:wght@200;300;400;500;600;700&family=Yrsa:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -31,7 +31,7 @@ export const GlobalStyle = createGlobalStyle`
     font-weight: 700;
     font-style: normal;
   }
-    @font-face {
+  @font-face {
     font-family: 'ZCOOL QingKe HuangYou';
     src: url('/fonts/ZCOOLQingKeHuangYou-Regular.ttf') format('truetype');
     font-weight: 400;
@@ -57,7 +57,7 @@ export const GlobalStyle = createGlobalStyle`
     background: ${({ theme }) => theme.COLORS.WHITE};
     word-break: break-word;
     word-wrap: break-word;
-    font-family: "Mplus1Code", "Inter", "BlinkMacSystemFont", "Hiragino Kaku Gothic ProN",
+    font-family: "M PLUS 1p", "Inter", "BlinkMacSystemFont", "Hiragino Kaku Gothic ProN",
       "Hiragino Sans", Meiryo, sans-serif;
     font-weight: 500;
   }


### PR DESCRIPTION
## 実装の概要
チラつき現象は自分たちでは直せないのでGoogle fontsで代用する提案

## 目的

## レビューして欲しいところ

## 不安に思っていること
ネットワークが遅い学校でしっかり読み込まれるかどうか

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連
[styled-componentsの公式](https://github.com/styled-components/styled-components/issues/3333)
[chromiumのバグ報告](https://bugs.chromium.org/p/chromium/issues/detail?id=1216451)

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
