### PR TITLE
fix: ゲームログを最新25件取得してくる

### DIFF
--- a/api/src/game-logs/game-logs.resolver.ts
+++ b/api/src/game-logs/game-logs.resolver.ts
@@ -8,7 +8,7 @@ export class GameLogsResolver {
   constructor(private gameLogService: GameLogsService) {}
 
   @Query(() => [GameLog])
-  public async findByProjectId(
+  public async findLogsByProjectId(
     @Args({ name: 'project_id' }) project_id: string,
   ) {
     return await this.gameLogService

--- a/api/src/game-logs/game-logs.service.ts
+++ b/api/src/game-logs/game-logs.service.ts
@@ -23,9 +23,16 @@ export class GameLogsService {
 
   findByProjectId(project_id: string): Promise<GameLog[]> {
     const logs = this.gameLogRepository.find({
-      project: {
-        id: project_id,
+      where: {
+        project: {
+          id: project_id,
+        },
       },
+      order: {
+        created_at: 'DESC',
+      },
+      take: 25,
+      relations: ['user'],
     });
 
     if (!logs) throw new NotFoundException();

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -137,8 +137,6 @@ export class ProjectsService {
       .leftJoinAndSelect('tasks.allocations', 'allocations')
       .leftJoinAndSelect('tasks.chats', 'chats')
       .leftJoinAndSelect('allocations.user', 'allocationsUser')
-      .leftJoinAndSelect('project.gameLogs', 'gameLogs')
-      .leftJoinAndSelect('gameLogs.user', 'gameLogsUser')
       .leftJoinAndSelect('project.groups', 'groups')
       .leftJoinAndSelect('groups.user', 'groupsUser')
       .leftJoinAndSelect('groupsUser.interests', 'interests')

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -184,7 +184,7 @@ type Query {
   listsByProjectId(projectId: String!): [List!]!
   completedTask(userId: String!): [Allocation!]!
   getChats(taskId: Float!): [Chat!]!
-  findByProjectId(project_id: String!): [GameLog!]!
+  findLogsByProjectId(project_id: String!): [GameLog!]!
 }
 
 input ProjectDetailUserSearchInput {

--- a/frontend/src/components/models/project/ProjectRight.tsx
+++ b/frontend/src/components/models/project/ProjectRight.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import { useGameLog } from 'hooks/useGameLog'
+import React, { FC, useState } from 'react'
 import styled from 'styled-components'
 import { GameLogType } from 'types/gameLog'
 import {
@@ -15,7 +16,6 @@ type Props = {
   monsterName: string
   monsterHPRemaining: number
   monsterHp: number
-  gameLogs: GameLogType[]
 }
 
 export const ProjectRight: FC<Props> = ({
@@ -24,8 +24,9 @@ export const ProjectRight: FC<Props> = ({
   monsterName,
   monsterHPRemaining,
   monsterHp,
-  gameLogs,
 }) => {
+  const [gameLogs] = useGameLog()
+
   return (
     <StyledProjectRightContainer className={className}>
       <ProjectCreateListButton onClick={onClick} />

--- a/frontend/src/components/models/project/ProjectRight.tsx
+++ b/frontend/src/components/models/project/ProjectRight.tsx
@@ -1,5 +1,5 @@
-import { useGameLog } from 'hooks/useGameLog'
 import React, { FC, useState } from 'react'
+import { useGameLog } from 'hooks/useGameLog'
 import styled from 'styled-components'
 import { GameLogType } from 'types/gameLog'
 import {

--- a/frontend/src/hooks/useGameLog.ts
+++ b/frontend/src/hooks/useGameLog.ts
@@ -1,0 +1,35 @@
+import { useGetGameLogsByProjectIdLazyQuery } from 'pages/projectDetail/projectDetail.gen'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { GameLogType } from 'types/gameLog'
+
+export const useGameLog = () => {
+  const { id: projectId } = useParams()
+  const [gameLogs, setGameLogs] = useState<GameLogType[]>([])
+  const [getGameLogsByProjectId] = useGetGameLogsByProjectIdLazyQuery({
+    onCompleted(data) {
+      data.findLogsByProjectId.map(gameLog => {
+        const time = new Date(gameLog.created_at)
+
+        const init: GameLogType = {
+          context: gameLog.context,
+          userName: gameLog.user.name,
+          createdAt: time.getTime(),
+        }
+        setGameLogs(gameLog => [...gameLog, init])
+      })
+    },
+  })
+
+  useEffect(() => {
+    if (!projectId) return
+
+    getGameLogsByProjectId({
+      variables: {
+        project_id: projectId,
+      },
+    })
+  }, [projectId])
+
+  return [gameLogs]
+}

--- a/frontend/src/hooks/useGameLog.ts
+++ b/frontend/src/hooks/useGameLog.ts
@@ -1,5 +1,5 @@
-import { useGetGameLogsByProjectIdLazyQuery } from 'pages/projectDetail/projectDetail.gen'
 import { useEffect, useState } from 'react'
+import { useGetGameLogsByProjectIdLazyQuery } from 'pages/projectDetail/projectDetail.gen'
 import { useParams } from 'react-router-dom'
 import { GameLogType } from 'types/gameLog'
 

--- a/frontend/src/pages/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectDetail/ProjectDetail.tsx
@@ -19,7 +19,6 @@ import { useInput } from 'hooks/useInput'
 import { useDebounce } from 'hooks/useDebounce'
 import { List } from 'types/list'
 import { Task } from 'types/task'
-import { GameLogType } from 'types/gameLog'
 import { DROP_TYPE } from 'consts/dropType'
 import { ProjectDrawer } from 'components/models/project/ProjectDrawer'
 import { ProjectRight } from 'components/models/project/ProjectRight'
@@ -41,17 +40,6 @@ export const ProjectDetail: FC = () => {
     onCompleted(data) {
       data.getProjectById.groups.map(group => {
         setSelectUserIds(groupList => [...groupList, group.user.id])
-      })
-
-      data.getProjectById.gameLogs.map(gameLog => {
-        const time = new Date(gameLog.created_at)
-        logger.debug(gameLog)
-        const init = {
-          context: gameLog.context,
-          userName: gameLog.user.name,
-          createdAt: time.getTime(),
-        }
-        setLogs(log => [...log, init].sort((a, b) => a.createdAt - b.createdAt))
       })
 
       const sortList: List[] = data.getProjectById.lists.map(list => {
@@ -224,7 +212,6 @@ export const ProjectDetail: FC = () => {
   })
 
   const [list, setList] = useState<List[]>([])
-  const [logs, setLogs] = useState<GameLogType[]>([])
   const debouncedInputText = useDebounce<string>(inputUserName.value, 500)
 
   const handleBeforeUnloadEvent = async (userId: string, projectId: string) => {
@@ -472,7 +459,6 @@ export const ProjectDetail: FC = () => {
             monsterHPRemaining={monsterHPRemaining}
             monsterHp={projectData.data.getProjectById.hp}
             monsterName={projectData.data.getProjectById.monster.name}
-            gameLogs={logs}
           />
         </ProjectDetailRightContainer>
       </ProjectDetailContainer>

--- a/frontend/src/pages/projectDetail/projectDetail.gql
+++ b/frontend/src/pages/projectDetail/projectDetail.gql
@@ -5,17 +5,6 @@ query GetProject($id: String!) {
     hp
     difficulty
 
-    gameLogs {
-      id
-      context
-      created_at
-
-      user {
-        id
-        name
-      }
-    }
-
     monster {
       id
       name
@@ -95,6 +84,19 @@ query SearchUsers($searchUser: ProjectDetailUserSearchInput!) {
 
     invitations {
       id
+    }
+  }
+}
+
+query GetGameLogsByProjectId($project_id: String!) {
+  findLogsByProjectId(project_id: $project_id) {
+    id
+    context
+    created_at
+
+    user {
+      id
+      name
     }
   }
 }


### PR DESCRIPTION
## 実装の概要
ゲームログを今まで全て取ってきたのを最新25件取得するようにする

Trello #162
Closes #162

## 目的
今後ログの数が増えるため

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
