### PR TITLE
React.FCの型を拡張してFCXを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ frontend/
             ├─ styles/
 ```
 
-| ディレクトリ | 役割                   |
-| ------------ | ---------------------- |
-| components   | ui: 各パーツ models: ビジネスロジック   |
-| pages        | 各ページのトップ |
-| hooks        | hooks関数       |
-| consts       | 変更が無い値     |
-| providers    | providerの設定       |
-| routes       | ルーティングの設定      |
-| utils        | 通常関数            |
-| env          | env系の設定       |
-| styles       | 初期スタイル設定       |
+| ディレクトリ | 役割                                  |
+| ------------ | ------------------------------------- |
+| components   | ui: 各パーツ models: ビジネスロジック |
+| pages        | 各ページのトップ                      |
+| hooks        | hooks 関数                            |
+| consts       | 変更が無い値                          |
+| providers    | provider の設定                       |
+| routes       | ルーティングの設定                    |
+| utils        | 通常関数                              |
+| env          | env 系の設定                          |
+| styles       | 初期スタイル設定                      |
 
 ### コード規約
 
@@ -79,18 +79,19 @@ frontend/
     - アクター: 人事、一般ユーザー
   - 例えば、同じ画面でも一般ユーザーと人事で表示内容が異なる場合、それぞれでコンポーネントを分ける
     - テキストが少し分岐する程度なら分けなくても良いが、処理そのものが変わるような場合は分ける
-- コンポーネント作成時は、必ず props で className を受け取れれうようにし、一番外側の要素に className を渡すようにする
-  - これをしないと、`styled(Component)``` のようにコンポーネントをスタイル拡張する際に、スタイルが付与できなくなる
-  - 詳しくはこの記事を参考: [TypeScript 利用時の styled-components の拡張方法について - Qiita](https://qiita.com/s-age/items/d85fc08ed8650c5361c1)
-  ```tsx
-  type Props = {
-    className?: string;
-  };
+- コンポーネント作成時は、props で className を受け取れるようにするために、FCX の型を仕様する
 
-  const Text: FC<Props> = (props) => {
+  - これをしないと、`styled(Component)``` のようにコンポーネントをスタイル拡張する際に、スタイルが付与できなくなる
+  - 詳しくはこの記事を参考: [React.FC 型を拡張する - Qiita](https://qiita.com/Takepepe/items/f66c7e2e1d22b431f148)
+
+  ```tsx
+  import React, { FCX } from "react";
+
+  const Text: FCX<Props> = (props) => {
     return <Component className={props.className}>hoge</Component>;
   };
   ```
+
 - コンポーネントに margin をつけない
   - 参考: [UI コンポーネントにはマージンをつけるな！絶対にだ！！ - Qiita](https://qiita.com/otsukayuhi/items/d88b5158745f700be534)
 

--- a/frontend/src/components/models/employee/EmployeeInformation.tsx
+++ b/frontend/src/components/models/employee/EmployeeInformation.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { GetUserQuery } from 'pages/mypage/mypage.gen'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { usePopover } from 'hooks/usePopover'
@@ -9,11 +9,9 @@ import { StatusBar } from 'components/ui/item/StatusBar'
 import Exp from 'utils/exp/exp'
 import styled, { css } from 'styled-components'
 
-type Props = {
-  className?: string
-} & Omit<GetUserQuery['user'], 'company' | 'memo' | 'invitations'>
+type Props = Omit<GetUserQuery['user'], 'company' | 'memo' | 'invitations'>
 
-export const EmployeeInformation: FC<Props> = ({
+export const EmployeeInformation: FCX<Props> = ({
   id,
   occupation_id,
   name,

--- a/frontend/src/components/models/employee/EmployeeOnlineStatusLabel.tsx
+++ b/frontend/src/components/models/employee/EmployeeOnlineStatusLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import {
   calculateMinSizeBasedOnFigma,
   calculateMinSizeBasedOnFigmaWidth,
@@ -6,12 +6,11 @@ import {
 import styled, { css } from 'styled-components'
 
 type Props = {
-  className?: string
   label: string
   status: boolean
 }
 
-export const EmployeeOnlineStatusLabel: FC<Props> = ({ label, status }) => {
+export const EmployeeOnlineStatusLabel: FCX<Props> = ({ label, status }) => {
   return (
     <StyledContainer>
       <StyledCircle status={status} />

--- a/frontend/src/components/models/employee/EmployeePopover.tsx
+++ b/frontend/src/components/models/employee/EmployeePopover.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { GetUserQuery } from 'pages/mypage/mypage.gen'
 import { occupationList } from 'consts/occupationList'
 import { PopoverProps } from 'types/popover'
@@ -16,12 +16,11 @@ import { Tag } from 'components/ui/tag/Tag'
 import styled, { css } from 'styled-components'
 
 type Props = {
-  className?: string
   level: number
 } & PopoverProps &
   Omit<GetUserQuery['user'], 'company' | 'memo' | 'exp' | 'online_flg' | 'invitations'>
 
-export const EmployeePopover: FC<Props> = ({
+export const EmployeePopover: FCX<Props> = ({
   id,
   occupation_id,
   name,

--- a/frontend/src/components/models/employee/EmployeeProjectMembers.tsx
+++ b/frontend/src/components/models/employee/EmployeeProjectMembers.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { GetProjectQuery } from 'pages/projectDetail/projectDetail.gen'
 import {
   calculateMinSizeBasedOnFigmaWidth,
@@ -9,12 +9,9 @@ import { EmployeeInformation } from 'components/models/employee/EmployeeInformat
 import styled from 'styled-components'
 
 type Groups = Pick<GetProjectQuery['getProjectById'], 'groups'>
+type Props = Partial<Groups>
 
-type Props = {
-  className?: string
-} & Partial<Groups>
-
-export const EmployeeProjectMembers: FC<Props> = ({ groups }) => {
+export const EmployeeProjectMembers: FCX<Props> = ({ groups }) => {
   return (
     <StyledContainer>
       <StyledLabelContainer>

--- a/frontend/src/components/models/employee/EmployeeSignBoard.tsx
+++ b/frontend/src/components/models/employee/EmployeeSignBoard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -6,12 +6,11 @@ import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import { faCaretLeft } from '@fortawesome/free-solid-svg-icons'
 
 type Props = {
-  className?: string
   isOpen: boolean
   handleClick: () => void
 }
 
-export const EmployeeSignBoard: FC<Props> = ({ className, isOpen, handleClick }) => {
+export const EmployeeSignBoard: FCX<Props> = ({ className, isOpen, handleClick }) => {
   return (
     <StyledContainer className={className} onClick={handleClick}>
       <StyledH3>MEMBER</StyledH3>

--- a/frontend/src/components/models/employee/EmployeeStatus.tsx
+++ b/frontend/src/components/models/employee/EmployeeStatus.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { StatusParam } from 'types/status'
 import { convertParamIntoJp } from 'utils/convertParamIntoJp'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -10,7 +10,7 @@ type Props = {
   value: number
 }
 
-export const EmployeeStatus: FC<Props> = ({ param, value }) => {
+export const EmployeeStatus: FCX<Props> = ({ param, value }) => {
   const rank = Status.toRank(value)
   const proficiency = Status.toRemainderStatus(value)
 

--- a/frontend/src/components/models/monster/MonsterAvatar.tsx
+++ b/frontend/src/components/models/monster/MonsterAvatar.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, VFC } from 'react'
+import React, { Suspense, useRef, FCX } from 'react'
 import { Mesh } from 'three'
 import { Environment, OrbitControls } from '@react-three/drei'
 import { Canvas, useFrame } from '@react-three/fiber'
@@ -6,7 +6,7 @@ import Model from './DragonIdle'
 import styled from 'styled-components'
 import { calculateVhBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 
-export const MonsterAvatar: VFC = () => {
+export const MonsterAvatar: FCX = () => {
   return (
     <StyledMonsterAvatarContainer>
       <Canvas camera={{ fov: 3.8, position: [12, 4, 12] }}>

--- a/frontend/src/components/models/myPage/MyPageStatus.tsx
+++ b/frontend/src/components/models/myPage/MyPageStatus.tsx
@@ -1,10 +1,9 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { MyPageStatusCard, STATUS_TYPE } from './MyPageStatusCard'
 
 type Props = {
-  className?: string
   technology: number
   solution: number
   achievement: number
@@ -13,7 +12,7 @@ type Props = {
   plan: number
 }
 
-export const MyPageStatus: FC<Props> = ({
+export const MyPageStatus: FCX<Props> = ({
   className,
   technology,
   solution,

--- a/frontend/src/components/models/myPage/MyPageStatusCard.tsx
+++ b/frontend/src/components/models/myPage/MyPageStatusCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import {
   achievementLabelColor,
@@ -13,7 +13,6 @@ import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import status from 'utils/status/status'
 
 type Props = {
-  className?: string
   statusType: STATUS_TYPE
   statValue: number
 }
@@ -28,7 +27,7 @@ export const STATUS_TYPE = {
 } as const
 type STATUS_TYPE = typeof STATUS_TYPE[keyof typeof STATUS_TYPE]
 
-export const MyPageStatusCard: FC<Props> = ({ className, statusType, statValue }) => {
+export const MyPageStatusCard: FCX<Props> = ({ className, statusType, statValue }) => {
   const defaultImgFolder = '/myPageStatus'
 
   const statusTitle = (statusType: STATUS_TYPE) => {

--- a/frontend/src/components/models/myPage/MyPageTags.tsx
+++ b/frontend/src/components/models/myPage/MyPageTags.tsx
@@ -1,12 +1,11 @@
+import React, { FCX } from 'react'
 import { EditButton } from 'components/ui/button/EditButton'
-import React, { FC } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import logger from 'utils/debugger/logger'
 import { Tag, TAG_TYPE } from 'components/ui/tag/Tag'
 
 type Props = {
-  className?: string
   interests: {
     __typename?: 'Interest' | undefined
     id: number
@@ -19,7 +18,7 @@ type Props = {
   }[]
 }
 
-export const MyPageTags: FC<Props> = ({ className, interests, certifications }) => {
+export const MyPageTags: FCX<Props> = ({ className, interests, certifications }) => {
   // TODO: モーダルが追加されたらonClickを変更していく
   return (
     <StyledMyPageTagsContainer className={className}>

--- a/frontend/src/components/models/myPage/MyPageUserInfo.tsx
+++ b/frontend/src/components/models/myPage/MyPageUserInfo.tsx
@@ -1,12 +1,11 @@
+import React, { FCX } from 'react'
 import { occupationList } from 'consts/occupationList'
-import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import exp from 'utils/exp/exp'
 
 type Props = {
-  className?: string
   iconImage: string
   name: string
   uid: string
@@ -17,7 +16,7 @@ type Props = {
   mp: number
 }
 
-export const MyPageUserInfo: FC<Props> = ({
+export const MyPageUserInfo: FCX<Props> = ({
   className,
   iconImage,
   name,

--- a/frontend/src/components/models/project/ProjectDrawer.tsx
+++ b/frontend/src/components/models/project/ProjectDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd'
 import { StyledMaterialUiMain } from 'styles/mui/StyledMaterialUiMain'
 import { DROP_TYPE } from 'consts/dropType'
@@ -22,7 +22,7 @@ type Props = {
   onDragEnd: (result: DropResult) => Promise<void>
 } & Partial<Groups>
 
-export const ProjectDrawer: FC<Props> = ({ groups, lists, onDragEnd }) => {
+export const ProjectDrawer: FCX<Props> = ({ groups, lists, onDragEnd }) => {
   const { currentValue, setCurrentValue } = useLocalStorage<boolean>('isOpen', true)
 
   return (

--- a/frontend/src/components/models/project/ProjectGameLog.tsx
+++ b/frontend/src/components/models/project/ProjectGameLog.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { GameLogType } from 'types/gameLog'
 import { calculateMinSizeBasedOnFigmaHeight } from 'utils/calculateSizeBasedOnFigma'
@@ -6,11 +6,10 @@ import { GAME_LOG_TYPE } from 'consts/gameLog'
 import { theme } from 'styles/theme'
 
 type Props = {
-  className?: string
   gameLogs: GameLogType[]
 }
 
-export const ProjectGameLog: FC<Props> = ({ className, gameLogs }) => {
+export const ProjectGameLog: FCX<Props> = ({ className, gameLogs }) => {
   const endText = (context: string) => {
     if (context.includes(GAME_LOG_TYPE.CREATE_PROJECT)) {
       return 'が出現した！'

--- a/frontend/src/components/models/project/ProjectMonster.tsx
+++ b/frontend/src/components/models/project/ProjectMonster.tsx
@@ -1,15 +1,14 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   name: string
   hpRemaining: number
   hp: number
 }
 
-export const ProjectMonster: FC<Props> = ({ className, name, hp, hpRemaining }) => {
+export const ProjectMonster: FCX<Props> = ({ className, name, hp, hpRemaining }) => {
   return (
     <StyledProjectMonster className={className}>
       <StyledMonsterStatus>

--- a/frontend/src/components/models/project/ProjectMyBars.tsx
+++ b/frontend/src/components/models/project/ProjectMyBars.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { BAR_TYPE } from 'consts/bar'
 import { yanoneKaffeesatz } from 'styles/fontFamily/fontFamily'
@@ -6,13 +6,12 @@ import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFig
 import exp from 'utils/exp/exp'
 
 type Props = {
-  className?: string
   hp: number
   mp: number
   totalExp: number
 }
 
-export const ProjectMyBars: FC<Props> = ({ className, hp, mp, totalExp }) => {
+export const ProjectMyBars: FCX<Props> = ({ className, hp, mp, totalExp }) => {
   return (
     <StyledProjectMyBarsContainer className={className}>
       <StyledStatusHPBarContainer>

--- a/frontend/src/components/models/project/ProjectMyInfo.tsx
+++ b/frontend/src/components/models/project/ProjectMyInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { occupationList } from 'consts/occupationList'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -7,7 +7,6 @@ import { ProjectMyBars } from './ProjectMyBars'
 import { ProjectMyStatuses } from './ProjectMyStatuses'
 
 type Props = {
-  className?: string
   iconImage: string
   occupationId: number
   name: string
@@ -22,7 +21,7 @@ type Props = {
   plan: number
 }
 
-export const ProjectMyInfo: FC<Props> = ({
+export const ProjectMyInfo: FCX<Props> = ({
   className,
   iconImage,
   occupationId,

--- a/frontend/src/components/models/project/ProjectMyStatuses.tsx
+++ b/frontend/src/components/models/project/ProjectMyStatuses.tsx
@@ -1,11 +1,10 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { yrsa } from 'styles/fontFamily/fontFamily'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import status from 'utils/status/status'
 
 type Props = {
-  className?: string
   technology: number
   solution: number
   achievement: number
@@ -16,7 +15,7 @@ type Props = {
 
 type StatusType = 'technology' | 'solution' | 'achievement' | 'motivation' | 'design' | 'plan'
 
-export const ProjectMyStatuses: FC<Props> = ({
+export const ProjectMyStatuses: FCX<Props> = ({
   className,
   technology,
   solution,

--- a/frontend/src/components/models/project/ProjectRight.tsx
+++ b/frontend/src/components/models/project/ProjectRight.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FCX, useState } from 'react'
 import { useGameLog } from 'hooks/useGameLog'
 import styled from 'styled-components'
 import { GameLogType } from 'types/gameLog'
@@ -6,19 +6,18 @@ import {
   calculateMinSizeBasedOnFigmaHeight,
   calculateMinSizeBasedOnFigmaWidth,
 } from 'utils/calculateSizeBasedOnFigma'
-import { CreateListButton } from '../../ui/button/CreateListButton'
+import { CreateListButton } from 'components/ui/button/CreateListButton'
 import { ProjectGameLog } from './ProjectGameLog'
 import { ProjectMonster } from './ProjectMonster'
 
 type Props = {
-  className?: string
   onClick: () => void
   monsterName: string
   monsterHPRemaining: number
   monsterHp: number
 }
 
-export const ProjectRight: FC<Props> = ({
+export const ProjectRight: FCX<Props> = ({
   className,
   onClick,
   monsterName,

--- a/frontend/src/components/models/task/TaskCard.tsx
+++ b/frontend/src/components/models/task/TaskCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { Task } from 'types/task'
 import { Params } from 'types/status'
@@ -14,13 +14,12 @@ import date from 'utils/date/date'
 import styled, { css } from 'styled-components'
 
 type Props = {
-  className?: string
   taskIndex: number
   listIndex: number
   listLength: number
 } & Omit<Task, 'vertical_sort'>
 
-export const TaskCard: FC<Props> = ({
+export const TaskCard: FCX<Props> = ({
   id,
   title,
   technology,

--- a/frontend/src/components/models/task/TaskColumn.tsx
+++ b/frontend/src/components/models/task/TaskColumn.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FCX, useState } from 'react'
 import { Draggable, Droppable } from 'react-beautiful-dnd'
 import { List } from 'types/list'
 import { DROP_TYPE } from 'consts/dropType'
@@ -24,12 +24,11 @@ import TextareaAutosize from '@mui/material/TextareaAutosize'
 import styled, { css } from 'styled-components'
 
 type Props = {
-  className?: string
   listIndex: number
   listLength: number
 } & Omit<List, 'sort_id' | 'index'>
 
-export const TaskColumn: FC<Props> = ({ id, list_id, title, tasks, listIndex, listLength }) => {
+export const TaskColumn: FCX<Props> = ({ id, list_id, title, tasks, listIndex, listLength }) => {
   const listTitle = useInput(title)
   const controll = useControllTextArea()
   const { anchorEl, openPopover, closePopover } = usePopover()

--- a/frontend/src/components/models/task/TaskColumnList.tsx
+++ b/frontend/src/components/models/task/TaskColumnList.tsx
@@ -1,13 +1,12 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { List } from 'types/list'
 import { TaskColumn } from 'components/models/task/TaskColumn'
 
 type Props = {
-  className?: string
   lists: List[]
 }
 
-export const TaskColumnList: FC<Props> = ({ lists }) => {
+export const TaskColumnList: FCX<Props> = ({ lists }) => {
   return (
     <>
       {lists.map((list, listIndex, { length }) => (

--- a/frontend/src/components/models/task/TaskCreateModal.tsx
+++ b/frontend/src/components/models/task/TaskCreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Dispatch, SetStateAction } from 'react'
+import React, { FCX, Dispatch, SetStateAction } from 'react'
 import styled, {
   css,
   FlattenInterpolation,
@@ -27,7 +27,7 @@ type Props = {
   list_id: string
 }
 
-export const TaskCreateModal: FC<Props> = ({
+export const TaskCreateModal: FCX<Props> = ({
   shouldShow,
   setShouldShow,
   className,

--- a/frontend/src/components/models/task/TaskList.tsx
+++ b/frontend/src/components/models/task/TaskList.tsx
@@ -1,15 +1,14 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { Task } from 'types/task'
 import { TaskCard } from 'components/models/task/TaskCard'
 
 type Props = {
-  className?: string
   listIndex: number
   listLength: number
   tasks: Task[]
 }
 
-export const TaskList: FC<Props> = ({ tasks, listIndex, listLength }) => {
+export const TaskList: FCX<Props> = ({ tasks, listIndex, listLength }) => {
   return (
     <>
       {tasks.map((task, index) => (

--- a/frontend/src/components/models/task/TaskStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskStatusPointField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, Dispatch, SetStateAction } from 'react'
+import React, { FCX, useEffect, useRef, Dispatch, SetStateAction } from 'react'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { theme } from 'styles/theme'
 import styled, { css, FlattenInterpolation, ThemeProps, DefaultTheme } from 'styled-components'
@@ -9,7 +9,6 @@ import { StatusParam } from 'types/status'
 import { INITIAL_STATUS_COUNTS } from 'consts/status'
 
 type Props = {
-  className?: string
   status: StatusParam
   statusCounts: Record<StatusParam, number>
   setStatusCounts: Dispatch<SetStateAction<Record<StatusParam, number>>>
@@ -17,7 +16,7 @@ type Props = {
 
 const isEqual = <T,>(a: T, b: T) => JSON.stringify(a) === JSON.stringify(b)
 
-export const TaskStatusPointField: FC<Props> = ({
+export const TaskStatusPointField: FCX<Props> = ({
   className,
   status,
   statusCounts,

--- a/frontend/src/components/models/user/UserAccountSettingModal.tsx
+++ b/frontend/src/components/models/user/UserAccountSettingModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, Dispatch, SetStateAction } from 'react'
+import React, { FCX, useState, Dispatch, SetStateAction } from 'react'
 import { theme } from 'styles/theme'
 import { REGEX_EMAIL, REGEX_TEXT } from 'consts/regex'
 import { Modal } from 'components/ui/modal/Modal'
@@ -30,7 +30,7 @@ type Props = {
   className?: string
 }
 
-export const UserAccountSettingModal: FC<Props> = ({ shouldShow, setShouldShow, className }) => {
+export const UserAccountSettingModal: FCX<Props> = ({ shouldShow, setShouldShow, className }) => {
   const { currentUser } = useAuthContext()
   const {
     register,

--- a/frontend/src/components/ui/avatar/ManyUserAvatar.tsx
+++ b/frontend/src/components/ui/avatar/ManyUserAvatar.tsx
@@ -1,6 +1,6 @@
+import React, { FCX } from 'react'
 import { AVATAR_STYLE } from 'consts/avatarStyle'
 import { occupationList } from 'consts/occupationList'
-import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 import type { UserDatas } from 'types/userDatas'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -14,10 +14,9 @@ type Props = {
   onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   userDatas: UserDatas
   userCount: number
-  className?: string
 }
 
-export const ManyUserAvatar: FC<Props> = ({
+export const ManyUserAvatar: FCX<Props> = ({
   avatarStyleType,
   onClickDeleteBtn,
   userDatas,

--- a/frontend/src/components/ui/avatar/UserAvatarIcon.tsx
+++ b/frontend/src/components/ui/avatar/UserAvatarIcon.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { useHover } from 'hooks/useHover'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
@@ -10,11 +10,10 @@ type Props = {
   iconImage: string
   name?: string
   occupation?: string
-  className?: string
   onClickDeleteBtn?: () => void
 }
 
-export const UserAvatarIcon: FC<Props> = ({
+export const UserAvatarIcon: FCX<Props> = ({
   avatarStyleType,
   iconImage,
   onClickDeleteBtn,

--- a/frontend/src/components/ui/avatar/UserCount.tsx
+++ b/frontend/src/components/ui/avatar/UserCount.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react'
+import React, { FCX, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { AVATAR_STYLE } from 'consts/avatarStyle'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
@@ -10,11 +10,10 @@ type Props = {
   userCount: number
   avatarStyleType: AVATAR_STYLE
   userDatas?: UserDatas
-  className?: string
   onClickDeleteBtn?: (index: number) => void
 }
 
-export const UserCount: FC<Props> = ({
+export const UserCount: FCX<Props> = ({
   userCount,
   avatarStyleType,
   userDatas = [],

--- a/frontend/src/components/ui/button/CoarseButton.tsx
+++ b/frontend/src/components/ui/button/CoarseButton.tsx
@@ -1,16 +1,15 @@
-import React, { FC, MouseEvent } from 'react'
+import React, { FCX, MouseEvent } from 'react'
 import styled, { css } from 'styled-components'
 
 type BgSrc = '/grain.png' | '/light-grain.png'
 type Props = {
-  className?: string
   text: string
   bgSrcs?: Record<'outer' | 'inner', BgSrc>
   onClick?: (e: MouseEvent) => void
   disabled?: boolean
 }
 
-export const CoarseButton: FC<Props> = ({
+export const CoarseButton: FCX<Props> = ({
   className,
   text,
   bgSrcs = { inner: '/grain.png', outer: '/grain.png' },

--- a/frontend/src/components/ui/button/ComplicateButton.tsx
+++ b/frontend/src/components/ui/button/ComplicateButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { calculateMinSizeBasedOnFigmaHeight } from 'utils/calculateSizeBasedOnFigma'
@@ -15,7 +15,7 @@ export const BUTTON_COLOR_TYPE = {
 } as const
 type BUTTON_COLOR_TYPE = typeof BUTTON_COLOR_TYPE[keyof typeof BUTTON_COLOR_TYPE]
 
-export const ComplicateButton: FC<Props> = ({ buttonColorType, text, onClick }) => {
+export const ComplicateButton: FCX<Props> = ({ buttonColorType, text, onClick }) => {
   return (
     <StyledComplicateButton onClick={onClick}>
       <img src={`/svg/${buttonColorType}`} alt="ボタン画像" />

--- a/frontend/src/components/ui/button/CreateListButton.tsx
+++ b/frontend/src/components/ui/button/CreateListButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import {
   calculateMinSizeBasedOnFigmaHeight,
@@ -6,11 +6,10 @@ import {
 } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   onClick: () => void
 }
 
-export const CreateListButton: FC<Props> = ({ className, onClick }) => {
+export const CreateListButton: FCX<Props> = ({ className, onClick }) => {
   return <StyledCreateListButton className={className} onClick={onClick} />
 }
 

--- a/frontend/src/components/ui/button/CreateTaskButton.tsx
+++ b/frontend/src/components/ui/button/CreateTaskButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { theme } from 'styles/theme'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -8,7 +8,7 @@ type Props = {
   onClick: () => void
 }
 
-export const CreateTaskButton: FC<Props> = ({ onClick }) => {
+export const CreateTaskButton: FCX<Props> = ({ onClick }) => {
   return <StyledContainer onClick={onClick}>+ タスクを追加</StyledContainer>
 }
 

--- a/frontend/src/components/ui/button/EditButton.tsx
+++ b/frontend/src/components/ui/button/EditButton.tsx
@@ -1,13 +1,12 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   onClick: () => void
 }
 
-export const EditButton: FC<Props> = ({ className, onClick }) => {
+export const EditButton: FCX<Props> = ({ className, onClick }) => {
   return (
     <StyledEditButton className={className} onClick={onClick}>
       編集

--- a/frontend/src/components/ui/button/ModalButton.tsx
+++ b/frontend/src/components/ui/button/ModalButton.tsx
@@ -1,17 +1,16 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { strokeTextShadow } from 'utils/strokeTextShadow'
 
 type Props = {
-  className?: string
   onClick?: () => void
   disabled?: boolean
   text: string
 }
 
-export const ModalButton: FC<Props> = ({ className, onClick, text, disabled = false }) => {
+export const ModalButton: FCX<Props> = ({ className, onClick, text, disabled = false }) => {
   return (
     <StyledButton className={className} onClick={onClick} disabled={disabled}>
       <StyledText>{text}</StyledText>

--- a/frontend/src/components/ui/button/SimpleRoundedButton.tsx
+++ b/frontend/src/components/ui/button/SimpleRoundedButton.tsx
@@ -1,13 +1,12 @@
-import React, { FC, MouseEvent } from 'react'
+import React, { FCX, MouseEvent } from 'react'
 import styled from 'styled-components'
 
 type Props = {
-  className?: string
   text: string
   onClick?: (e: MouseEvent) => void
 }
 
-export const SimpleRoundedButton: FC<Props> = ({ className, text, onClick }) => {
+export const SimpleRoundedButton: FCX<Props> = ({ className, text, onClick }) => {
   return (
     <StyledButton className={className} onClick={onClick}>
       {text}

--- a/frontend/src/components/ui/error/ErrorScreen.tsx
+++ b/frontend/src/components/ui/error/ErrorScreen.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 
 type Props = {
   error: Error
 }
 
-export const ErrorScreen: FC<Props> = ({ error }) => {
+export const ErrorScreen: FCX<Props> = ({ error }) => {
   return (
     <StyledErrorContainer>
       <h3>we are sorry... something went wrong.</h3>

--- a/frontend/src/components/ui/form/CalenderField.tsx
+++ b/frontend/src/components/ui/form/CalenderField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, InputHTMLAttributes, useState, FocusEvent, ReactNode } from 'react'
+import React, { FCX, useEffect, InputHTMLAttributes, useState, FocusEvent, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
@@ -6,7 +6,6 @@ import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 
 type Props = {
-  className?: string
   label?: string
   error?: FieldError | undefined
   children?: ReactNode
@@ -15,7 +14,7 @@ type Props = {
   required?: boolean
 } & InputHTMLAttributes<HTMLInputElement>
 
-export const CalenderField: FC<Props> = ({
+export const CalenderField: FCX<Props> = ({
   className,
   errorColor = theme.COLORS.ERROR,
   label,

--- a/frontend/src/components/ui/form/ImageInputField.tsx
+++ b/frontend/src/components/ui/form/ImageInputField.tsx
@@ -1,18 +1,17 @@
-import React, { FC, useRef } from 'react'
+import React, { FCX, useRef } from 'react'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   image: string
   defaultSrc: string
   handleUploadImg: (e: React.ChangeEvent<HTMLInputElement>) => void
   initializeUploadImg: () => void
 }
 
-export const ImageInputField: FC<Props> = ({
+export const ImageInputField: FCX<Props> = ({
   className,
   image,
   defaultSrc,

--- a/frontend/src/components/ui/form/InputField.tsx
+++ b/frontend/src/components/ui/form/InputField.tsx
@@ -1,11 +1,10 @@
-import React, { FC, useEffect, InputHTMLAttributes, useState, FocusEvent, ReactNode } from 'react'
+import React, { FCX, useEffect, InputHTMLAttributes, useState, FocusEvent, ReactNode } from 'react'
 import styled from 'styled-components'
 import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 
 type Props = {
-  className?: string
   label?: string
   error?: FieldError | undefined
   children?: ReactNode
@@ -15,7 +14,7 @@ type Props = {
   type?: 'text' | 'email' | 'password'
 } & InputHTMLAttributes<HTMLInputElement>
 
-export const InputField: FC<Props> = ({
+export const InputField: FCX<Props> = ({
   className,
   errorColor = theme.COLORS.ERROR,
   label,

--- a/frontend/src/components/ui/form/InputItem.tsx
+++ b/frontend/src/components/ui/form/InputItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent } from 'react'
+import React, { FCX, MouseEvent } from 'react'
 import styled from 'styled-components'
 import { CrossIcon } from 'components/ui/icon/CrossIcon'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
@@ -6,12 +6,11 @@ import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   itemName: string
   onClick?: (e: MouseEvent) => void
 }
 
-export const InputItem: FC<Props> = ({ className, itemName, onClick }) => {
+export const InputItem: FCX<Props> = ({ className, itemName, onClick }) => {
   return (
     <StyledOuterWrapper className={className}>
       <StyledOuterMask>

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, Dispatch } from 'react'
+import React, { FCX, useEffect, Dispatch } from 'react'
 import styled, { css } from 'styled-components'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
 import { InputItem } from 'components/ui/form/InputItem'
@@ -10,7 +10,6 @@ import { max } from 'consts/certificationsAndInterests'
 
 type InputAspectStyles = Record<'width' | 'height', string>
 type Props = {
-  className?: string
   label: string
   placeholder?: string
   inputAspect: InputAspectStyles
@@ -18,7 +17,7 @@ type Props = {
   setItems: Dispatch<React.SetStateAction<string[]>>
 }
 
-export const ItemInputField: FC<Props> = props => {
+export const ItemInputField: FCX<Props> = props => {
   const { className, label, placeholder, inputAspect, setItems } = props
   const {
     value,

--- a/frontend/src/components/ui/form/PasswordField.tsx
+++ b/frontend/src/components/ui/form/PasswordField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, InputHTMLAttributes, ReactNode, useState, ChangeEvent } from 'react'
+import React, { FCX, InputHTMLAttributes, ReactNode, useState, ChangeEvent } from 'react'
 import styled, { css } from 'styled-components'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { InputField } from 'components/ui/form/InputField'
@@ -7,7 +7,6 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 
 type Props = {
-  className?: string
   label?: string
   error?: FieldError | undefined
   children?: ReactNode
@@ -17,7 +16,7 @@ type Props = {
   type?: 'text' | 'password'
 } & InputHTMLAttributes<HTMLInputElement>
 
-export const PasswordField: FC<Props> = ({
+export const PasswordField: FCX<Props> = ({
   className,
   type = 'password',
   registration,

--- a/frontend/src/components/ui/form/SearchMemberField.tsx
+++ b/frontend/src/components/ui/form/SearchMemberField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, Dispatch, SetStateAction } from 'react'
+import React, { FCX, useEffect, Dispatch, SetStateAction } from 'react'
 import { AVATAR_STYLE } from 'consts/avatarStyle'
 import { occupationList } from 'consts/occupationList'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
@@ -11,12 +11,11 @@ import { UserCount } from 'components/ui/avatar/UserCount'
 import type { UserDatas } from 'types/userDatas'
 
 type Props = {
-  className?: string
   setUserDatas: Dispatch<SetStateAction<UserDatas>>
   userDatas: UserDatas
 }
 
-export const SearchMemberField: FC<Props> = ({ className, setUserDatas, userDatas }) => {
+export const SearchMemberField: FCX<Props> = ({ className, setUserDatas, userDatas }) => {
   const {
     onChange,
     onFocus,

--- a/frontend/src/components/ui/form/SelectField.tsx
+++ b/frontend/src/components/ui/form/SelectField.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC,
+  FCX,
   useEffect,
   SelectHTMLAttributes,
   useState,
@@ -13,7 +13,6 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 
 type Props = {
-  className?: string
   label?: string
   error?: FieldError | undefined
   registration: Partial<UseFormRegisterReturn>
@@ -23,7 +22,7 @@ type Props = {
   options: Record<'value' | 'item', string>[]
 } & SelectHTMLAttributes<HTMLSelectElement>
 
-export const SelectField: FC<Props> = ({
+export const SelectField: FCX<Props> = ({
   className,
   options,
   errorColor = theme.COLORS.ERROR,

--- a/frontend/src/components/ui/form/TextAreaField.tsx
+++ b/frontend/src/components/ui/form/TextAreaField.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC,
+  FCX,
   useEffect,
   TextareaHTMLAttributes,
   useState,
@@ -12,7 +12,6 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 
 type Props = {
-  className?: string
   label?: string
   error?: FieldError | undefined
   children?: ReactNode
@@ -22,7 +21,7 @@ type Props = {
   type?: 'text' | 'email' | 'password'
 } & TextareaHTMLAttributes<HTMLTextAreaElement>
 
-export const TextAreaField: FC<Props> = ({
+export const TextAreaField: FCX<Props> = ({
   className,
   errorColor = theme.COLORS.ERROR,
   label,

--- a/frontend/src/components/ui/header/AuthHeader.tsx
+++ b/frontend/src/components/ui/header/AuthHeader.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { SimpleRoundedButton } from 'components/ui/button/SimpleRoundedButton'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { useNavigate } from 'react-router-dom'
 
-export const AuthHeader: FC = () => {
+export const AuthHeader: FCX = () => {
   const navigate = useNavigate()
 
   return (

--- a/frontend/src/components/ui/header/InvitaionHeader.tsx
+++ b/frontend/src/components/ui/header/InvitaionHeader.tsx
@@ -1,9 +1,8 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   handlers:
     | boolean
     | {
@@ -13,7 +12,7 @@ type Props = {
   onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
-export const InvitationHeader: FC<Props> = ({ className, handlers, onClick }) => {
+export const InvitationHeader: FCX<Props> = ({ className, handlers, onClick }) => {
   return (
     <StyledInvitationHeaderContainer className={className} {...handlers} onClick={onClick}>
       <p>招待</p>

--- a/frontend/src/components/ui/header/NotificationHeader.tsx
+++ b/frontend/src/components/ui/header/NotificationHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import {
   calculateMinSizeBasedOnFigmaHeight,
@@ -6,7 +6,6 @@ import {
 } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   handlers:
     | boolean
     | {
@@ -17,7 +16,12 @@ type Props = {
   isNotification: boolean
 }
 
-export const NotificationHeader: FC<Props> = ({ className, handlers, onClick, isNotification }) => {
+export const NotificationHeader: FCX<Props> = ({
+  className,
+  handlers,
+  onClick,
+  isNotification,
+}) => {
   return (
     <StyledNotificationHeaderContainer className={className} {...handlers} onClick={onClick}>
       <img src="/svg/bell.svg" alt="通知アイコン" />

--- a/frontend/src/components/ui/header/ProjectDetailHeader.tsx
+++ b/frontend/src/components/ui/header/ProjectDetailHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react'
+import React, { FCX, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import { Notifications } from 'types/notification'
@@ -20,7 +20,6 @@ import { SearchTaskPopup } from 'components/ui/popup/SearchTaskPopup'
 import { UserAccountSettingModal } from 'components/models/user/UserAccountSettingModal'
 
 type Props = {
-  className?: string
   iconImage: string
   name: string
   uid: string
@@ -30,7 +29,7 @@ type Props = {
   list: List[]
 }
 
-export const ProjectDetailHeader: FC<Props> = ({
+export const ProjectDetailHeader: FCX<Props> = ({
   className,
   iconImage,
   name,

--- a/frontend/src/components/ui/header/ProjectListHeader.tsx
+++ b/frontend/src/components/ui/header/ProjectListHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react'
+import React, { FCX, useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -12,7 +12,6 @@ import { UserMenuHeader } from 'components/ui/header/UserMenuHeader'
 import { NotificationHeader } from 'components/ui/header/NotificationHeader'
 
 type Props = {
-  className?: string
   iconImage: string
   name: string
   uid: string
@@ -20,7 +19,7 @@ type Props = {
   notifications: Notifications
 }
 
-export const ProjectListHeader: FC<Props> = ({
+export const ProjectListHeader: FCX<Props> = ({
   className,
   iconImage,
   name,

--- a/frontend/src/components/ui/header/UserMenuHeader.tsx
+++ b/frontend/src/components/ui/header/UserMenuHeader.tsx
@@ -1,9 +1,8 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 
 type Props = {
-  className?: string
   handlers:
     | boolean
     | {
@@ -14,7 +13,7 @@ type Props = {
   onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
-export const UserMenuHeader: FC<Props> = ({ className, handlers, iconImage, onClick }) => {
+export const UserMenuHeader: FCX<Props> = ({ className, handlers, iconImage, onClick }) => {
   return (
     <StyledUserMenuHeaderContainer {...handlers} onClick={onClick} className={className}>
       <StyledUserMenuIcon>

--- a/frontend/src/components/ui/icon/CrossIcon.tsx
+++ b/frontend/src/components/ui/icon/CrossIcon.tsx
@@ -1,15 +1,14 @@
-import React, { FC, MouseEvent, SVGAttributes } from 'react'
+import React, { FCX, MouseEvent, SVGAttributes } from 'react'
 import styled from 'styled-components'
 
 type Props = {
-  className?: string
   onClick?: (e: MouseEvent) => void
   color: string
   strokeLinecap?: SVGAttributes<SVGPathElement>['strokeLinecap']
   strokeWidth?: SVGAttributes<SVGPathElement>['strokeWidth']
 }
 
-export const CrossIcon: FC<Props> = ({
+export const CrossIcon: FCX<Props> = ({
   className,
   onClick,
   color,

--- a/frontend/src/components/ui/item/Avatar.tsx
+++ b/frontend/src/components/ui/item/Avatar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { DEFAUT_USER } from 'consts/defaultImages'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import styled, { css } from 'styled-components'
@@ -6,12 +6,11 @@ import styled, { css } from 'styled-components'
 type StyleSize = 'small' | 'normal' | 'large'
 
 type Props = {
-  className?: string
   image: string
   size: StyleSize
 }
 
-export const Avatar: FC<Props> = ({ className, image, size }) => {
+export const Avatar: FCX<Props> = ({ className, image, size }) => {
   return (
     <StyledAvatar
       className={className}

--- a/frontend/src/components/ui/item/Level.tsx
+++ b/frontend/src/components/ui/item/Level.tsx
@@ -1,16 +1,15 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import styled, { css } from 'styled-components'
 
 type StyleSize = 'small' | 'normal' | 'large'
 
 type Props = {
-  className?: string
   level: number
   size: StyleSize
 }
 
-export const Level: FC<Props> = ({ className, level, size }) => {
+export const Level: FCX<Props> = ({ className, level, size }) => {
   return <StyledLevel className={className} size={size}>{`lv.${level}`}</StyledLevel>
 }
 

--- a/frontend/src/components/ui/item/Occupation.tsx
+++ b/frontend/src/components/ui/item/Occupation.tsx
@@ -1,16 +1,15 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import styled, { css } from 'styled-components'
 
 type StyleSize = 'small' | 'normal' | 'large'
 
 type Props = {
-  className?: string
   occupation: string
   size: StyleSize
 }
 
-export const Occupation: FC<Props> = ({ className, occupation, size }) => {
+export const Occupation: FCX<Props> = ({ className, occupation, size }) => {
   return (
     <StyledOccupation className={className} size={size}>
       {occupation}

--- a/frontend/src/components/ui/item/StatusBar.tsx
+++ b/frontend/src/components/ui/item/StatusBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import styled, { css } from 'styled-components'
 
@@ -12,7 +12,7 @@ type Props = {
   onlineFlg: boolean
 }
 
-export const StatusBar: FC<Props> = ({ type, size, rate, onlineFlg }) => {
+export const StatusBar: FCX<Props> = ({ type, size, rate, onlineFlg }) => {
   return <StyledStatusBar type={type} size={size} rate={rate} onlineFlg={onlineFlg} />
 }
 

--- a/frontend/src/components/ui/loading/Loading.tsx
+++ b/frontend/src/components/ui/loading/Loading.tsx
@@ -1,10 +1,10 @@
-import React, { FC, useEffect } from 'react'
+import React, { FCX, useEffect } from 'react'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import nowLoading from './loading.json'
 import lottie from 'lottie-web'
 import styled from 'styled-components'
 
-export const Loading: FC = () => {
+export const Loading: FCX = () => {
   useEffect(() => {
     lottie.loadAnimation({
       container: document.querySelector('#now-loading') as HTMLDivElement,

--- a/frontend/src/components/ui/modal/BasicPopover.tsx
+++ b/frontend/src/components/ui/modal/BasicPopover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FCX, ReactNode } from 'react'
 import Popover, { PopoverOrigin } from '@mui/material/Popover'
 import { PopoverProps } from 'types/popover'
 
@@ -6,7 +6,7 @@ type Props = {
   children: ReactNode
 } & PopoverProps
 
-export const BasicPopover: FC<Props> = ({
+export const BasicPopover: FCX<Props> = ({
   children,
   anchorEl,
   vertical,

--- a/frontend/src/components/ui/modal/Modal.tsx
+++ b/frontend/src/components/ui/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, ReactNode } from 'react'
+import React, { FCX, MouseEvent, ReactNode } from 'react'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { strokeTextShadow } from 'utils/strokeTextShadow'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
@@ -10,11 +10,10 @@ type Props = {
   title?: string
   shouldShow: boolean
   onClickCloseBtn: (e?: MouseEvent) => void
-  className?: string
   children: ReactNode
 }
 
-export const Modal: FC<Props> = ({
+export const Modal: FCX<Props> = ({
   title = 'タスク作成',
   shouldShow,
   onClickCloseBtn,

--- a/frontend/src/components/ui/modal/SmallPopover.tsx
+++ b/frontend/src/components/ui/modal/SmallPopover.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { PopoverProps } from 'types/popover'
 import { theme } from 'styles/theme'
 import { BasicPopover } from 'components/ui/modal/BasicPopover'
@@ -9,12 +9,11 @@ import { faPencilAlt, faEraser } from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
 
 type Props = {
-  className?: string
   handleEdit: (e?: any) => void //FIXME Colmun.tsxでeが必要だけど、他ではいらない場合の型の指定が不明
   handleRemove: () => void
 } & PopoverProps
 
-export const SmallPopover: FC<Props> = ({
+export const SmallPopover: FCX<Props> = ({
   anchorEl,
   vertical,
   horizontal,

--- a/frontend/src/components/ui/popup/CoverPopup.tsx
+++ b/frontend/src/components/ui/popup/CoverPopup.tsx
@@ -1,13 +1,11 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FCX, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
-import logger from 'utils/debugger/logger'
 import { theme } from 'styles/theme'
 import { CrossIcon } from 'components/ui/icon/CrossIcon'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 
 type Props = {
-  className?: string
   popupType: POPUP_TYPE
   title: string
   children: ReactNode
@@ -24,7 +22,7 @@ export const POPUP_TYPE = {
 } as const
 export type POPUP_TYPE = typeof POPUP_TYPE[keyof typeof POPUP_TYPE]
 
-export const CoverPopup: FC<Props> = ({
+export const CoverPopup: FCX<Props> = ({
   className,
   popupType,
   title,

--- a/frontend/src/components/ui/popup/InvitationPopup.tsx
+++ b/frontend/src/components/ui/popup/InvitationPopup.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react'
+import React, { FCX, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { CoverPopup, POPUP_TYPE } from 'components/ui/popup/CoverPopup'
@@ -14,14 +14,13 @@ import { useParams } from 'react-router'
 import toast from 'utils/toast/toast'
 
 type Props = {
-  className?: string
   isHover: boolean
   isClick: boolean
   company: string
   closeClick: () => void
 }
 
-export const InvitationPopup: FC<Props> = ({
+export const InvitationPopup: FCX<Props> = ({
   className,
   isHover,
   isClick,

--- a/frontend/src/components/ui/popup/NotificationPopup.tsx
+++ b/frontend/src/components/ui/popup/NotificationPopup.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useEffect, useState } from 'react'
-import styled, { css } from 'styled-components'
+import React, { FCX, useEffect, useState } from 'react'
+import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { CoverPopup, POPUP_TYPE } from 'components/ui/popup/CoverPopup'
 import date from 'utils/date/date'
@@ -7,14 +7,13 @@ import logger from 'utils/debugger/logger'
 import { Notifications } from 'types/notification'
 
 type Props = {
-  className?: string
   isHover: boolean
   isClick: boolean
   closeClick: () => void
   notifications: Notifications
 }
 
-export const NotificationPopup: FC<Props> = ({
+export const NotificationPopup: FCX<Props> = ({
   className,
   isHover,
   isClick,

--- a/frontend/src/components/ui/popup/SearchTaskPopup.tsx
+++ b/frontend/src/components/ui/popup/SearchTaskPopup.tsx
@@ -1,19 +1,16 @@
-import { title } from 'process'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FCX, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { SearchTask } from 'types/task'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
-import logger from 'utils/debugger/logger'
 import { TaskCardPopup } from './TaskCardPopup'
 
 type Props = {
-  className?: string
   searchedTasks: SearchTask[]
 }
 
 // TODO: モーダルが出来次第、タスクモーダルが開く処理をかく
-export const SearchTaskPopup: FC<Props> = ({ className, searchedTasks }) => {
+export const SearchTaskPopup: FCX<Props> = ({ className, searchedTasks }) => {
   const [isTask, setIsTask] = useState(false)
 
   useEffect(() => {

--- a/frontend/src/components/ui/popup/TaskCardPopup.tsx
+++ b/frontend/src/components/ui/popup/TaskCardPopup.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { Task } from 'types/task'
 import { Params } from 'types/status'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
@@ -13,12 +13,11 @@ import date from 'utils/date/date'
 import styled, { css } from 'styled-components'
 
 type Props = {
-  className?: string
   listIndex: number
   listLength: number
 } & Omit<Task, 'vertical_sort' | 'id' | 'allocations'>
 
-export const TaskCardPopup: FC<Props> = ({
+export const TaskCardPopup: FCX<Props> = ({
   title,
   technology,
   achievement,

--- a/frontend/src/components/ui/popup/UserMenuPopup.tsx
+++ b/frontend/src/components/ui/popup/UserMenuPopup.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, SetStateAction, Dispatch } from 'react'
+import React, { FCX, useState, SetStateAction, Dispatch } from 'react'
 import { Link } from 'react-router-dom'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { useTrySignOut } from 'hooks/useTrySignOut'
@@ -7,7 +7,6 @@ import Exp from 'utils/exp/exp'
 import styled from 'styled-components'
 
 type Props = {
-  className?: string
   isHover: boolean
   isClick: boolean
   closeClick: () => void
@@ -18,7 +17,7 @@ type Props = {
   setShouldShowModal: Dispatch<SetStateAction<boolean>>
 }
 
-export const UserMenuPopup: FC<Props> = ({
+export const UserMenuPopup: FCX<Props> = ({
   className,
   isHover,
   isClick,

--- a/frontend/src/components/ui/projectList/ProjectListItem.tsx
+++ b/frontend/src/components/ui/projectList/ProjectListItem.tsx
@@ -1,11 +1,10 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { calculateMinSizeBasedOnFigmaHeight } from 'utils/calculateSizeBasedOnFigma'
 import date from 'utils/date/date'
 
 type Props = {
-  className?: string
   isEnd: boolean
   activeStatue: ACTIVE_STATUS
   projectTitle: string
@@ -25,7 +24,7 @@ export const ACTIVE_STATUS = {
 } as const
 type ACTIVE_STATUS = typeof ACTIVE_STATUS[keyof typeof ACTIVE_STATUS]
 
-export const ProjectListItem: FC<Props> = ({
+export const ProjectListItem: FCX<Props> = ({
   className,
   isEnd,
   activeStatue,

--- a/frontend/src/components/ui/projectList/ProjectListMonster.tsx
+++ b/frontend/src/components/ui/projectList/ProjectListMonster.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import { RatingView } from 'react-simple-star-rating'
 import styled from 'styled-components'
 import { MonsterAvatar } from 'components/models/monster/MonsterAvatar'
@@ -11,7 +11,7 @@ type Props = {
   limitDeadline: string
 }
 
-export const ProjectListMonster: FC<Props> = ({ specie, difficulty, limitDeadline }) => {
+export const ProjectListMonster: FCX<Props> = ({ specie, difficulty, limitDeadline }) => {
   return (
     <StyledMonsterContainer>
       <MonsterAvatar />

--- a/frontend/src/components/ui/projectList/ProjectListProjectInfo.tsx
+++ b/frontend/src/components/ui/projectList/ProjectListProjectInfo.tsx
@@ -1,6 +1,6 @@
+import React, { FCX, useMemo } from 'react'
 import { AVATAR_STYLE } from 'consts/avatarStyle'
 import { occupationList } from 'consts/occupationList'
-import React, { FC, useMemo } from 'react'
 import styled from 'styled-components'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { useCalculateOverUsers } from 'hooks/useCalculateOverUsers'
@@ -50,7 +50,7 @@ type Props = {
   }[]
 }
 
-export const ProjectListProjectInfo: FC<Props> = ({
+export const ProjectListProjectInfo: FCX<Props> = ({
   story,
   overview,
   selectProject,

--- a/frontend/src/components/ui/tag/Tag.tsx
+++ b/frontend/src/components/ui/tag/Tag.tsx
@@ -1,11 +1,10 @@
-import React, { FC } from 'react'
+import React, { FCX } from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { CrossIcon } from 'components/ui/icon/CrossIcon'
 
 type Props = {
-  className?: string
   name: string
   onClick?: () => void
   tagType: TAG_TYPE
@@ -19,7 +18,7 @@ export const TAG_TYPE = {
 } as const
 export type TAG_TYPE = typeof TAG_TYPE[keyof typeof TAG_TYPE]
 
-export const Tag: FC<Props> = ({ className, name, onClick, tagType }) => {
+export const Tag: FCX<Props> = ({ className, name, onClick, tagType }) => {
   return (
     <StyledTagContainer className={className}>
       <StyledTagTriangle tagType={tagType} />

--- a/frontend/src/consts/companyList.ts
+++ b/frontend/src/consts/companyList.ts
@@ -1,0 +1,6 @@
+export const companyList: string[] = [
+  'HAL TOKYO',
+  'HAL NAGOUYA',
+  'HAL OOSAKA',
+  '株式会社本質',
+];

--- a/frontend/src/consts/companyList.ts
+++ b/frontend/src/consts/companyList.ts
@@ -1,6 +1,0 @@
-export const companyList: string[] = [
-  'HAL TOKYO',
-  'HAL NAGOUYA',
-  'HAL OOSAKA',
-  '株式会社本質',
-];

--- a/frontend/src/pages/invitation/index.tsx
+++ b/frontend/src/pages/invitation/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { FC, useEffect } from 'react'
 import { useAuthContext } from 'providers/AuthProvider'
 import { useNavigate, useParams } from 'react-router'
 import logger from 'utils/debugger/logger'
@@ -6,7 +6,7 @@ import { useGetInvitationByUserIdLazyQuery, useJoinProjectMutation } from './Inv
 import { GQL_ERROR_MESSAGE } from 'consts/gqlErrorMessage'
 import toast from 'utils/toast/toast'
 
-export const Invitation = () => {
+export const Invitation: FC = () => {
   const navigate = useNavigate()
   const { currentUser } = useAuthContext()
   const { projectId } = useParams()

--- a/frontend/src/type.ts
+++ b/frontend/src/type.ts
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+declare module 'react' {
+  type FCX<P = {}> = FunctionComponent<P & { className?: string }>
+}


### PR DESCRIPTION
## 実装の概要

propsで毎回className?:stringを指定しなくても良いようにFCX型を作成
[React.FC 型を拡張する - Qiita](https://qiita.com/Takepepe/items/f66c7e2e1d22b431f148)

Trello # <!-- trelloのタスクを進行中に移動したい場合 -->
Closes # <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
