### PR TITLE
feat: 職業テーブルの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ init-database:
 	docker compose exec db-server mysql -u root -p -e'CREATE DATABASE IF NOT EXISTS taosk_db; GRANT ALL PRIVILEGES ON taosk_db.* TO develop@"%";'
 sql:
 	docker compose exec db-server bash -c 'mysql -u $$MYSQL_USER -p$$MYSQL_PASSWORD $$MYSQL_DATABASE'
+prisma-generate:
+	cd api && yarn prisma:generate
+prisma-seed:
+	cd api && yarn prisma:seed
 create-model:
 	cd api && nest g mo ${name}
 create-resolver:

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ makefile のコマンドでも作れる
 | make build              | Container build                          |
 | make ps                 | Container list                           |
 | make sql                | Enter the SQL container                  |
+| make prisma-generate    | Generating the client                    |
+| make prisma-seed        | Seeding the database                     |
 | make generate-gql       | Graphql code gen generate command        |
 | make create-class       | Generate a new class                     |
 | make create-config      | Generate a CLI configuration file        |

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+# Keep environment variables out of version control
+.env

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prisma:generate": "prisma generate",
+    "prisma:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",
@@ -26,6 +31,7 @@
     "@nestjs/graphql": "^9.1.1",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/typeorm": "^8.0.2",
+    "@prisma/client": "^3.6.0",
     "@types/uuid": "^8.3.1",
     "apollo-server-express": "^3.4.0",
     "class-transformer": "^0.4.0",
@@ -55,6 +61,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.2.5",
     "prettier": "^2.3.2",
+    "prisma": "^3.6.0",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",

--- a/api/prisma/lib/occupation.ts
+++ b/api/prisma/lib/occupation.ts
@@ -1,0 +1,8 @@
+export const occupations: { name: string }[] = [
+  {
+    name: 'エンジニア',
+  },
+  {
+    name: 'デザイナー',
+  },
+];

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,0 +1,16 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = "mysql://develop:password@localhost:10000/taosk_db"
+}
+
+model Occupations {
+  id          Int     @id @default(autoincrement())
+  name        String  @unique
+}

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from '@prisma/client';
+import { occupations } from './lib/occupation';
+
+const prisma = new PrismaClient();
+async function main() {
+  for (const occupation of occupations) {
+    await prisma.occupations.upsert({
+      where: {
+        name: occupation.name,
+      },
+      create: occupation,
+      update: occupation,
+    });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/api/src/occupations/occupation.ts
+++ b/api/src/occupations/occupation.ts
@@ -1,5 +1,6 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from 'src/users/user';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 @Entity('occupations')
 @ObjectType()
 export class Occupation {
@@ -15,4 +16,8 @@ export class Occupation {
   })
   @Field()
   name: string;
+
+  @OneToMany(() => User, (user) => user.occupation)
+  @Field(() => [User])
+  users: User[];
 }

--- a/api/src/occupations/occupations.module.ts
+++ b/api/src/occupations/occupations.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Occupation } from './occupation';
+import { OccupationsService } from './occupations.service';
+import { OccupationsResolver } from './occupations.resolver';
 @Module({
   imports: [TypeOrmModule.forFeature([Occupation])],
+  providers: [OccupationsService, OccupationsResolver],
 })
 export class OccupationsModule {}

--- a/api/src/occupations/occupations.module.ts
+++ b/api/src/occupations/occupations.module.ts
@@ -3,8 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Occupation } from './occupation';
 import { OccupationsService } from './occupations.service';
 import { OccupationsResolver } from './occupations.resolver';
+import { User } from 'src/users/user';
 @Module({
-  imports: [TypeOrmModule.forFeature([Occupation])],
+  imports: [
+    TypeOrmModule.forFeature([Occupation]),
+    TypeOrmModule.forFeature([User]),
+  ],
   providers: [OccupationsService, OccupationsResolver],
 })
 export class OccupationsModule {}

--- a/api/src/occupations/occupations.resolver.spec.ts
+++ b/api/src/occupations/occupations.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OccupationsResolver } from './occupations.resolver';
+
+describe('OccupationsResolver', () => {
+  let resolver: OccupationsResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OccupationsResolver],
+    }).compile();
+
+    resolver = module.get<OccupationsResolver>(OccupationsResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/api/src/occupations/occupations.resolver.ts
+++ b/api/src/occupations/occupations.resolver.ts
@@ -1,12 +1,21 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Occupation } from './occupation';
 import { OccupationsService } from './occupations.service';
 
 @Resolver()
 export class OccupationsResolver {
   constructor(private occupationService: OccupationsService) {}
 
-  async getFindAll() {
+  @Query(() => [Occupation])
+  async getOccupations() {
     return await this.occupationService.find().catch((err) => {
+      throw err;
+    });
+  }
+
+  @Mutation(() => Occupation)
+  async creteOccupation(@Args({ name: 'name' }) name: string) {
+    return await this.occupationService.create(name).catch((err) => {
       throw err;
     });
   }

--- a/api/src/occupations/occupations.resolver.ts
+++ b/api/src/occupations/occupations.resolver.ts
@@ -1,0 +1,13 @@
+import { Resolver } from '@nestjs/graphql';
+import { OccupationsService } from './occupations.service';
+
+@Resolver()
+export class OccupationsResolver {
+  constructor(private occupationService: OccupationsService) {}
+
+  async getFindAll() {
+    return await this.occupationService.find().catch((err) => {
+      throw err;
+    });
+  }
+}

--- a/api/src/occupations/occupations.service.spec.ts
+++ b/api/src/occupations/occupations.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OccupationsService } from './occupations.service';
+
+describe('OccupationsService', () => {
+  let service: OccupationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OccupationsService],
+    }).compile();
+
+    service = module.get<OccupationsService>(OccupationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/src/occupations/occupations.service.ts
+++ b/api/src/occupations/occupations.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Occupation } from './occupation';
+
+@Injectable()
+export class OccupationsService {
+  constructor(
+    @InjectRepository(Occupation)
+    private occupationRepository: Repository<Occupation>,
+  ) {}
+
+  async find(): Promise<Occupation[]> {
+    const occupations = await this.occupationRepository.find();
+
+    if (!occupations) throw new NotFoundException();
+
+    return occupations;
+  }
+}

--- a/api/src/occupations/occupations.service.ts
+++ b/api/src/occupations/occupations.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Occupation } from './occupation';
@@ -9,6 +13,15 @@ export class OccupationsService {
     @InjectRepository(Occupation)
     private occupationRepository: Repository<Occupation>,
   ) {}
+
+  async create(name: string): Promise<Occupation> {
+    const occupation = this.occupationRepository.create({ name });
+    await this.occupationRepository.save(occupation).catch((err) => {
+      new InternalServerErrorException();
+    });
+
+    return occupation;
+  }
 
   async find(): Promise<Occupation[]> {
     const occupations = await this.occupationRepository.find();

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -184,6 +184,7 @@ type Query {
   allInterests: [Interest!]!
   interestsByUserIds(user_ids: [String!]!): [Interest!]!
   getCompany(uid: String!): Company!
+  getOccupations: [Occupation!]!
   getProjectById(id: String!): Project!
   invitation(projectId: String!, userId: String!): Invitation!
   invitations(userId: String!): [Invitation!]!
@@ -207,6 +208,7 @@ type Mutation {
   addCertification(newCertification: NewCertificationInput!): Certification!
   addInterest(newInterest: NewInterestInput!): Interest!
   addCompany(newCompany: NewCompanyInput!): Company!
+  creteOccupation(name: String!): Occupation!
   createProject(selectUser: SelectUser!, newProject: NewProjectInput!): Project!
   completedProject(endProject: EndProjectInput!): Boolean!
   joinProject(projectId: String!, userId: String!, invitationId: String!): Group!

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -135,6 +135,12 @@ type Group {
   deleted_at: DateTime!
 }
 
+type Occupation {
+  id: ID!
+  name: String!
+  users: [User!]!
+}
+
 type User {
   id: ID!
   name: String!
@@ -142,7 +148,6 @@ type User {
   online_flg: Boolean!
   hp: Float!
   mp: Float!
-  occupation_id: Float!
   company: String!
   memo: String!
   technology: Float!
@@ -159,6 +164,7 @@ type User {
   allocations: [Allocation!]!
   gameLogs: [GameLog!]!
   chat: [Chat!]!
+  occupation: Occupation!
   created_at: DateTime!
   updated_at: DateTime!
   deleted_at: DateTime!

--- a/api/src/users/user.ts
+++ b/api/src/users/user.ts
@@ -13,8 +13,11 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   OneToMany,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
 import { Chat } from 'src/chats/chat';
+import { Occupation } from 'src/occupations/occupation';
 
 @Entity('users')
 @ObjectType()
@@ -49,9 +52,9 @@ export class User {
   @Field()
   mp: number;
 
-  @Column({ type: 'int' })
-  @Field()
-  occupation_id: number;
+  // @Column({ type: 'int' })
+  // @Field()
+  // occupation_id: number;
 
   @Column({
     type: 'varchar',
@@ -122,6 +125,11 @@ export class User {
   @OneToMany(() => Chat, (chat) => chat.user)
   @Field(() => [Chat])
   chat: Chat[];
+
+  @ManyToOne(() => Occupation, (occupation) => occupation.users)
+  @Field(() => Occupation, { defaultValue: '' })
+  @JoinColumn({ name: 'occupation_id' })
+  occupation: Occupation;
 
   @CreateDateColumn()
   @Field()

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -9,6 +9,7 @@ import { Group } from 'src/groups/group';
 import { Invitation } from 'src/invitations/invitation';
 import { GameLog } from 'src/game-logs/game-log';
 import { Project } from 'src/projects/project';
+import { Occupation } from 'src/occupations/occupation';
 @Module({
   imports: [
     TypeOrmModule.forFeature([User]),
@@ -18,6 +19,7 @@ import { Project } from 'src/projects/project';
     TypeOrmModule.forFeature([Invitation]),
     TypeOrmModule.forFeature([Project]),
     TypeOrmModule.forFeature([GameLog]),
+    TypeOrmModule.forFeature([Occupation]),
   ],
   providers: [UsersResolver, UsersService],
   exports: [UsersService],

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -832,6 +832,23 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
+"@prisma/client@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.6.0.tgz#68a60cd4c73a369b11f72e173e86fd6789939293"
+  integrity sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==
+  dependencies:
+    "@prisma/engines-version" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+
+"@prisma/engines-version@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#25aa447776849a774885866b998732b37ec4f4f5"
+  integrity sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA==
+
+"@prisma/engines@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#c68ede6aeffa9ef7743a32cfa6daf9172a4e15b3"
+  integrity sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -4592,6 +4609,13 @@ pretty-format@^27.0.0, pretty-format@^27.3.1:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
+
+prisma@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.6.0.tgz#99532abc02e045e58c6133a19771bdeb28cecdbe"
+  integrity sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==
+  dependencies:
+    "@prisma/engines" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## 実装の概要
職業テーブルを追加

Trello #197
Closes #197

## 目的
職業をデータベースから取得する

## レビューして欲しいところ

## 不安に思っていること
- 現状, `generate-gql`ができない
  - gqlファイル, フロントを大幅に修正しないといけない

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
