### PR TITLE
feat: モンスターのデータを流し込むseedを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ prisma-generate:
 	cd api && yarn prisma:generate
 prisma-seed:
 	cd api && yarn prisma:seed
+prisma:
+	@make prisma-generate
+	@make prisma-seed
 create-model:
 	cd api && nest g mo ${name}
 create-resolver:

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ makefile のコマンドでも作れる
 | make sql                | Enter the SQL container                  |
 | make prisma-generate    | Generating the client                    |
 | make prisma-seed        | Seeding the database                     |
+| make prisma             | Running all prisma                       |
 | make generate-gql       | Graphql code gen generate command        |
 | make create-class       | Generate a new class                     |
 | make create-config      | Generate a CLI configuration file        |

--- a/api/prisma/lib/monster.ts
+++ b/api/prisma/lib/monster.ts
@@ -1,0 +1,12 @@
+export const monsters = [
+  {
+    id: 1,
+    name: 'What am i now',
+    type: 0,
+    story: '今の私は何',
+
+    specie: {
+      name: 'ドラゴン',
+    },
+  },
+];

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -11,6 +11,21 @@ datasource db {
 }
 
 model Occupations {
-  id          Int     @id @default(autoincrement())
-  name        String  @unique
+  id   Int    @id @default(autoincrement())
+  name String @unique
+}
+
+model Species {
+  id       Int        @id @default(autoincrement())
+  name     String     @unique
+  Monsters Monsters[]
+}
+
+model Monsters {
+  id        Int     @id
+  name      String  @unique
+  type      Int
+  story     String
+  specie    Species @relation(fields: [specie_id], references: [id])
+  specie_id Int
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,8 +1,14 @@
 import { PrismaClient } from '@prisma/client';
+import { monsters } from './lib/monster';
 import { occupations } from './lib/occupation';
 
 const prisma = new PrismaClient();
-async function main() {
+const main = async () => {
+  await occupationSeeder();
+  await monsterSeeder();
+};
+
+const occupationSeeder = async () => {
   for (const occupation of occupations) {
     await prisma.occupations.upsert({
       where: {
@@ -12,7 +18,41 @@ async function main() {
       update: occupation,
     });
   }
-}
+};
+
+const monsterSeeder = async () => {
+  for (const monster of monsters) {
+    await prisma.monsters.upsert({
+      where: {
+        id: monster.id,
+      },
+
+      create: {
+        id: monster.id,
+        name: monster.name,
+        type: monster.type,
+        story: monster.story,
+
+        specie: {
+          connectOrCreate: {
+            where: {
+              name: monster.specie.name,
+            },
+
+            create: monster.specie,
+          },
+        },
+      },
+
+      update: {
+        id: monster.id,
+        name: monster.name,
+        type: monster.type,
+        story: monster.story,
+      },
+    });
+  }
+};
 
 main()
   .catch((e) => {


### PR DESCRIPTION
## 実装の概要
モンスターのデータを流し込むseedを追加

## 目的
初期起動時、モンスターデータを追加し忘れる場面が多発してるため

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
