### PR TITLE
fix: タグのスタイルを新しいスタイルに変更

### DIFF
--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -1,12 +1,12 @@
 import React, { FCX, useEffect, Dispatch } from 'react'
 import styled, { css } from 'styled-components'
 import { CoarseButton } from 'components/ui/button/CoarseButton'
-import { InputItem } from 'components/ui/form/InputItem'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { useTextItems } from 'hooks/useTextItems'
 import { theme } from 'styles/theme'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { max } from 'consts/certificationsAndInterests'
+import { Tag, TAG_TYPE } from 'components/ui/tag/Tag'
 
 type InputAspectStyles = Record<'width' | 'height', string>
 type Props = {
@@ -52,7 +52,12 @@ export const ItemInputField: FCX<Props> = props => {
       </StyledRow>
       <StyledItemsWrapper width={inputAspect.width}>
         {items.map((item, index) => (
-          <InputItem itemName={item} key={index} onClick={() => onClickDeleteItemButton(item)} />
+          <Tag
+            name={item}
+            tagType={TAG_TYPE.SMALL}
+            key={index}
+            onClick={() => onClickDeleteItemButton(item)}
+          />
         ))}
       </StyledItemsWrapper>
     </StyledWrapper>


### PR DESCRIPTION
## 実装の概要
タグのスタイルを新しいスタイルに変更

Trello #175
Closes #175

## 目的
Figmaに新しいタグのスタイルが新しいのに変わっていたんでコード上も変更

## レビューして欲しいところ

## 不安に思っていること
`InputItem.tsx`を削除して良いものか

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
