### PR TITLE
fix: 資格と興味あることを17文字以内しか入力させないように

### DIFF
--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -27,7 +27,6 @@ export const ItemInputField: FCX<Props> = props => {
     onKeyPress,
     onClickAddButton,
     onClickDeleteItemButton,
-    isError,
   } = useTextItems(max.TEXT_LENGTH, max.ITEMS)
 
   useEffect(() => {
@@ -47,12 +46,12 @@ export const ItemInputField: FCX<Props> = props => {
           onKeyPress={onKeyPress}
           onChange={onChange}
           placeholder={placeholder}
-          isError={isError}
+          maxLength={17}
           {...inputAspect}
         />
         <StyledCoarseButton text="追加" onClick={onClickAddButton} disabled={isDisabled} />
       </StyledRow>
-      {isError && <StyledErrorMessage>17文字以内です</StyledErrorMessage>}
+
       <StyledItemsWrapper width={inputAspect.width}>
         {items.map((item, index) => (
           <InputItem itemName={item} key={index} onClick={() => onClickDeleteItemButton(item)} />
@@ -81,19 +80,13 @@ const StyledItemsNum = styled.span`
 const StyledMaxItems = styled.span<{ isMax: boolean }>`
   color: ${({ isMax }) => isMax && theme.COLORS.ERROR};
 `
-const StyledInput = styled.input<InputAspectStyles & { isError: boolean }>`
+const StyledInput = styled.input<InputAspectStyles >`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   padding-left: ${calculateMinSizeBasedOnFigma(8)};
   background-color: ${({ theme }) => convertIntoRGBA(theme.COLORS.WHITE, 0.7)};
   border: solid 1px ${({ theme }) => theme.COLORS.CHOCOLATE};
   border-radius: 2px;
-
-  ${({ isError }) =>
-    isError &&
-    css`
-      border-color: ${({ theme }) => theme.COLORS.ERROR};
-    `}
 
   &::placeholder {
     color: ${({ theme }) => theme.COLORS.GRAY};
@@ -138,9 +131,4 @@ const StyledCoarseButton = styled(CoarseButton).attrs<Disabled>(({ disabled }) =
       `
     }
   }}
-`
-
-const StyledErrorMessage = styled.div`
-  color: ${({ theme }) => theme.COLORS.ERROR};
-  font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
 `

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -27,6 +27,7 @@ export const ItemInputField: FCX<Props> = props => {
     onKeyPress,
     onClickAddButton,
     onClickDeleteItemButton,
+    isError,
   } = useTextItems(max.TEXT_LENGTH, max.ITEMS)
 
   useEffect(() => {
@@ -46,10 +47,12 @@ export const ItemInputField: FCX<Props> = props => {
           onKeyPress={onKeyPress}
           onChange={onChange}
           placeholder={placeholder}
+          isError={isError}
           {...inputAspect}
         />
         <StyledCoarseButton text="追加" onClick={onClickAddButton} disabled={isDisabled} />
       </StyledRow>
+      {isError && <StyledErrorMessage>17文字以内です</StyledErrorMessage>}
       <StyledItemsWrapper width={inputAspect.width}>
         {items.map((item, index) => (
           <InputItem itemName={item} key={index} onClick={() => onClickDeleteItemButton(item)} />
@@ -78,13 +81,20 @@ const StyledItemsNum = styled.span`
 const StyledMaxItems = styled.span<{ isMax: boolean }>`
   color: ${({ isMax }) => isMax && theme.COLORS.ERROR};
 `
-const StyledInput = styled.input<InputAspectStyles>`
+const StyledInput = styled.input<InputAspectStyles & { isError: boolean }>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   padding-left: ${calculateMinSizeBasedOnFigma(8)};
   background-color: ${({ theme }) => convertIntoRGBA(theme.COLORS.WHITE, 0.7)};
   border: solid 1px ${({ theme }) => theme.COLORS.CHOCOLATE};
   border-radius: 2px;
+
+  ${({ isError }) =>
+    isError &&
+    css`
+      border-color: ${({ theme }) => theme.COLORS.ERROR};
+    `}
+
   &::placeholder {
     color: ${({ theme }) => theme.COLORS.GRAY};
     font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
@@ -128,4 +138,9 @@ const StyledCoarseButton = styled(CoarseButton).attrs<Disabled>(({ disabled }) =
       `
     }
   }}
+`
+
+const StyledErrorMessage = styled.div`
+  color: ${({ theme }) => theme.COLORS.ERROR};
+  font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
 `

--- a/frontend/src/components/ui/form/ItemInputField.tsx
+++ b/frontend/src/components/ui/form/ItemInputField.tsx
@@ -80,7 +80,7 @@ const StyledItemsNum = styled.span`
 const StyledMaxItems = styled.span<{ isMax: boolean }>`
   color: ${({ isMax }) => isMax && theme.COLORS.ERROR};
 `
-const StyledInput = styled.input<InputAspectStyles >`
+const StyledInput = styled.input<InputAspectStyles>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   padding-left: ${calculateMinSizeBasedOnFigma(8)};

--- a/frontend/src/consts/certificationsAndInterests.ts
+++ b/frontend/src/consts/certificationsAndInterests.ts
@@ -1,4 +1,4 @@
 export const max = {
-  TEXT_LENGTH: 50,
+  TEXT_LENGTH: 17,
   ITEMS: 20,
 } as const

--- a/frontend/src/hooks/useTextItems.ts
+++ b/frontend/src/hooks/useTextItems.ts
@@ -8,7 +8,6 @@ type UseTextItemsReturn = {
   onKeyPress: KeyboardEventHandler<HTMLInputElement>
   onClickAddButton: () => void
   onClickDeleteItemButton: (item: string) => void
-  isError: boolean
 }
 
 /**
@@ -27,12 +26,10 @@ type UseTextItemsReturn = {
 export const useTextItems = (maxTextLength: number, maxItems: number): UseTextItemsReturn => {
   const [items, setItems] = useState<string[]>([])
   const [value, setValue] = useState<string>('')
-  const [isError, setIsError] = useState<boolean>(false)
   const [isDisabled, setIsDisabled] = useState<boolean>(true)
 
   const getShouldDisable = (value: string) => {
     const isAlreadyExists = !!items.find(v => v === value)
-    setIsError(value.length > maxTextLength)
     const isOver = value.length > maxTextLength || items.length >= maxItems
     return !value.trim() || !!isAlreadyExists || isOver
   }
@@ -73,6 +70,5 @@ export const useTextItems = (maxTextLength: number, maxItems: number): UseTextIt
     onKeyPress,
     onClickAddButton,
     onClickDeleteItemButton,
-    isError,
   }
 }

--- a/frontend/src/hooks/useTextItems.ts
+++ b/frontend/src/hooks/useTextItems.ts
@@ -8,6 +8,7 @@ type UseTextItemsReturn = {
   onKeyPress: KeyboardEventHandler<HTMLInputElement>
   onClickAddButton: () => void
   onClickDeleteItemButton: (item: string) => void
+  isError: boolean
 }
 
 /**
@@ -26,10 +27,12 @@ type UseTextItemsReturn = {
 export const useTextItems = (maxTextLength: number, maxItems: number): UseTextItemsReturn => {
   const [items, setItems] = useState<string[]>([])
   const [value, setValue] = useState<string>('')
+  const [isError, setIsError] = useState<boolean>(false)
   const [isDisabled, setIsDisabled] = useState<boolean>(true)
 
   const getShouldDisable = (value: string) => {
     const isAlreadyExists = !!items.find(v => v === value)
+    setIsError(value.length > maxTextLength)
     const isOver = value.length > maxTextLength || items.length >= maxItems
     return !value.trim() || !!isAlreadyExists || isOver
   }
@@ -70,5 +73,6 @@ export const useTextItems = (maxTextLength: number, maxItems: number): UseTextIt
     onKeyPress,
     onClickAddButton,
     onClickDeleteItemButton,
+    isError,
   }
 }

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -156,7 +156,7 @@ export const SignUp: FC = () => {
                 error={errors['occupation']}
               />
               <StyledItemInputField
-                label="保有資格"
+                label="保有資格(17文字以内)"
                 items={certifications}
                 setItems={setCertifications}
                 inputAspect={{
@@ -166,7 +166,7 @@ export const SignUp: FC = () => {
                 placeholder="保有資格を入力してください"
               />
               <StyledItemInputField
-                label="興味のあること"
+                label="興味のあること(17文字以内)"
                 items={interests}
                 setItems={setInterests}
                 inputAspect={{


### PR DESCRIPTION
## 実装の概要
新規登録の資格と興味あることを17文字以内に制限する

Trello #143
Closes #143

## 目的
文字が多すぎるとタグの背景画像がガタガタにあるため

## レビューして欲しいところ

## 不安に思っていること
ガタガタするぜぇ！

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
