### PR TITLE
feat/relationsOccupation

### DIFF
--- a/api/src/chats/chats.resolver.ts
+++ b/api/src/chats/chats.resolver.ts
@@ -14,7 +14,7 @@ export class ChatsResolver {
     });
   }
 
-  @Mutation(() => Chat)
+  @Mutation(() => [Chat])
   async addChat(
     @Args({ name: 'comment' }) comment: string,
     @Args({ name: 'taskId' }) taskId: number,

--- a/api/src/chats/chats.service.ts
+++ b/api/src/chats/chats.service.ts
@@ -60,6 +60,7 @@ export class ChatsService {
       relations: ['user', 'user.occupation'],
     });
     if (!chats) throw new NotFoundException();
+
     return chats;
   }
 

--- a/api/src/chats/chats.service.ts
+++ b/api/src/chats/chats.service.ts
@@ -27,7 +27,7 @@ export class ChatsService {
           id: taskId,
         },
       },
-      relations: ['user'],
+      relations: ['user', 'user.occupation'],
     });
     if (!chats) throw new NotFoundException();
 
@@ -38,19 +38,28 @@ export class ChatsService {
     comment: string,
     taskId: number,
     userId: string,
-  ): Promise<Chat> {
+  ): Promise<Chat[]> {
     const task = await this.taskRepository.findOne(taskId);
     const user = await this.userRepository.findOne(userId);
-    const chats = this.chatRepository.create({
+    const chat = this.chatRepository.create({
       comment: comment,
       task,
       user,
     });
 
-    await this.chatRepository.save(chats).catch(() => {
+    await this.chatRepository.save(chat).catch(() => {
       new InternalServerErrorException();
     });
 
+    const chats = this.chatRepository.find({
+      where: {
+        task: {
+          id: taskId,
+        },
+      },
+      relations: ['user', 'user.occupation'],
+    });
+    if (!chats) throw new NotFoundException();
     return chats;
   }
 
@@ -63,7 +72,7 @@ export class ChatsService {
       where: {
         id: chatId,
       },
-      relations: ['user'],
+      relations: ['user', 'user.occupation'],
     });
 
     chat.comment = comment;
@@ -78,7 +87,7 @@ export class ChatsService {
           id: taskId,
         },
       },
-      relations: ['user'],
+      relations: ['user', 'user.occupation'],
     });
     if (!chats) throw new NotFoundException();
 
@@ -102,7 +111,7 @@ export class ChatsService {
           id: taskId,
         },
       },
-      relations: ['user'],
+      relations: ['user', 'user.occupation'],
     });
     if (!chats) throw new NotFoundException();
 

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -226,7 +226,7 @@ type Mutation {
   deleteTask(taskId: Float!): [Task!]!
   createAllocation(newAllocation: NewAllocationInput!): Allocation!
   unAssignTask(task_id: Float!, user_id: String!): [Allocation!]!
-  addChat(userId: String!, taskId: Float!, comment: String!): Chat!
+  addChat(userId: String!, taskId: Float!, comment: String!): [Chat!]!
   updateChat(taskId: Float!, comment: String!, chatId: Float!): [Chat!]!
   deleteChat(taskId: Float!, chatId: Float!): [Chat!]!
   createGameLog(newLog: NewLogInput!): GameLog!

--- a/api/src/tasks/tasks.service.ts
+++ b/api/src/tasks/tasks.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Allocation } from 'src/allocations/allocation';
 import { AssignTaskInput } from 'src/allocations/dto/newAllocation.input';
+import { Chat } from 'src/chats/chat';
 import { GameLog } from 'src/game-logs/game-log';
 import { List } from 'src/lists/list';
 import { Project } from 'src/projects/project';
@@ -30,6 +31,8 @@ export class TasksService {
     private allocationRepository: Repository<Allocation>,
     @InjectRepository(GameLog)
     private gameLogRepository: Repository<GameLog>,
+    @InjectRepository(Chat)
+    private chatRepository: Repository<Chat>,
   ) {}
 
   async updateTaskSort(updateTask: UpdateTaskSort): Promise<Task[]> {
@@ -334,6 +337,12 @@ export class TasksService {
   async deleteTask(taskId: number): Promise<Task[]> {
     const task = await this.taskRepository.findOne({
       where: {
+        id: taskId,
+      },
+    });
+
+    await this.chatRepository.delete({
+      task: {
         id: taskId,
       },
     });


### PR DESCRIPTION
## 実装の概要
チャット取得時ユーザの職種も取得できるようにする
タスク消去する前に紐づいたチャットも削除

###やること
チャット取得時ユーザの職種の取得
タスク消去時紐づいたチャットも削除しないと外部キー的に消せなかったところを
チャット削除した後にタスク削除に修正

