### PR TITLE
bugfix: モンスターの総HPをフロント側で計算する

### DIFF
--- a/api/src/tasks/tasks.service.ts
+++ b/api/src/tasks/tasks.service.ts
@@ -159,19 +159,6 @@ export class TasksService {
     });
     if (!list) throw new NotFoundException();
 
-    const addMonsterHP =
-      newTask.technology +
-      newTask.achievement +
-      newTask.solution +
-      newTask.motivation +
-      newTask.plan +
-      newTask.design;
-
-    project.hp += addMonsterHP;
-    await this.projectRepository.save(project).catch((err) => {
-      throw err;
-    });
-
     const task = this.taskRepository.create({
       title: newTask.title,
       overview: newTask.overview,

--- a/frontend/src/pages/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectDetail/ProjectDetail.tsx
@@ -37,6 +37,7 @@ export const ProjectDetail: FC = () => {
   const [selectUserIds, setSelectUserIds] = useState<string[]>([])
   const [notifications, setNotifications] = useState<Notifications>([])
   const [monsterHPRemaining, setMonsterHPRemaining] = useState(0)
+  const [monsterTotalHP, setMonsterTotalHP] = useState(0)
   const inputUserName = useInput('')
   const [getProjectById, projectData] = useGetProjectLazyQuery({
     onCompleted(data) {
@@ -46,19 +47,20 @@ export const ProjectDetail: FC = () => {
 
       const sortList: List[] = data.getProjectById.lists.map(list => {
         const tasks = list.tasks.map(task => {
+          const totalStatusPoint =
+            task.technology +
+            task.achievement +
+            task.solution +
+            task.motivation +
+            task.plan +
+            task.design
+
           setMonsterHPRemaining(monsterHPRemaining => {
             if (task.completed_flg) return monsterHPRemaining
-
-            return (
-              monsterHPRemaining +
-              task.technology +
-              task.achievement +
-              task.solution +
-              task.motivation +
-              task.plan +
-              task.design
-            )
+            return monsterHPRemaining + totalStatusPoint
           })
+          setMonsterTotalHP(monsterTotalHP => monsterTotalHP + totalStatusPoint)
+
           const allocations = task.allocations.map(allocation => {
             return {
               id: allocation.user.id,
@@ -421,7 +423,7 @@ export const ProjectDetail: FC = () => {
           <ProjectRight
             onClick={handleCreateList}
             monsterHPRemaining={monsterHPRemaining}
-            monsterHp={projectData.data?.getProjectById.hp ?? 100}
+            monsterHp={monsterTotalHP}
             monsterName={projectData.data?.getProjectById.monster.name ?? ''}
           />
         </StyledProjectDetailRightContainer>


### PR DESCRIPTION
## 実装の概要
モンスターの総HPをフロント側で計算する

Trello #217
Closes #217

## 目的
バックで総HPを計算するのは大変なんで

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
