### PR TITLE
add,fix: タスク編集モーダルの完成 (連動スクロール、ポップオーバーの不具合修正)

### DIFF
--- a/frontend/src/components/models/task/TaskComment.tsx
+++ b/frontend/src/components/models/task/TaskComment.tsx
@@ -47,6 +47,7 @@ export const TaskComment: FCX<Props> = ({ taskId, chatInfo, isYour }) => {
       ) : (
         <StyledInputFormField>
           <StyledFlexTextarea
+            initialVal={chatInfo.comment}
             {...register('comment', {
               required: '未入力です',
               maxLength: { value: 255, message: '255文字以内で入力してください' },

--- a/frontend/src/components/models/task/TaskComment.tsx
+++ b/frontend/src/components/models/task/TaskComment.tsx
@@ -5,6 +5,7 @@ import { faEllipsisH } from '@fortawesome/free-solid-svg-icons'
 import { SmallPopover } from 'components/ui/popup/SmallPopover'
 import { FlexTextarea } from 'components/ui/textarea/FlexTextarea'
 import { CoarseRedOxideButton } from 'components/ui/button/CoarseRedOxideButton'
+import { UserAvatarIcon } from 'components/ui/avatar/UserAvatarIcon'
 import { usePopover } from 'hooks/usePopover'
 import { useHandleChat } from 'hooks/useHandleChat'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
@@ -28,56 +29,70 @@ export const TaskComment: FCX<Props> = ({ taskId, chatInfo, isYour }) => {
     })
 
   return (
-    <StyledTextWrapper>
-      <StyledCommentInfoRow>
-        <StyledCommentInfoP>
-          <StyledUserNameSpan>{chatInfo.user.name}</StyledUserNameSpan>
-          さんがコメントしました。&emsp;99分前
-        </StyledCommentInfoP>
-
-        {isYour && (
-          <StyledEllipsisButton onClick={openPopover}>
-            <StyledFontAwesomeIcon icon={faEllipsisH} />
-          </StyledEllipsisButton>
-        )}
-      </StyledCommentInfoRow>
-
-      {!isYour || state === 'view' ? (
-        <StyledCommentText>{chatInfo.comment}</StyledCommentText>
-      ) : (
-        <StyledInputFormField>
-          <StyledFlexTextarea
-            initialVal={chatInfo.comment}
-            {...register('comment', {
-              required: '未入力です',
-              maxLength: { value: 255, message: '255文字以内で入力してください' },
-              pattern: { value: /.*\S+.*/, message: '空白のみのコメントは投稿できません' },
-              validate: value => value !== chatInfo.comment,
-            })}
-          />
-
-          <StyledButtonWrapper>
-            <StyledCancelButton onClick={() => setState('view')}>
-              <StyledCancelText>キャンセル</StyledCancelText>
-            </StyledCancelButton>
-            <CoarseRedOxideButton text="保存" onClick={onClickUpdateButton} disabled={disabled} />
-          </StyledButtonWrapper>
-        </StyledInputFormField>
-      )}
-
-      <SmallPopover
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        handleClose={closePopover}
-        handleEdit={() => setState('edit')}
-        handleRemove={onClickDeleteButton}
+    <StyledCommentWrapper>
+      {/* TODO: occupationも取得できるようになったら追加する */}
+      <UserAvatarIcon
+        avatarStyleType="modal"
+        iconImage={chatInfo.user.icon_image}
+        name={chatInfo.user.name}
       />
-    </StyledTextWrapper>
+
+      <StyledTextWrapper>
+        <StyledCommentInfoRow>
+          <StyledCommentInfoP>
+            <StyledUserNameSpan>{chatInfo.user.name}</StyledUserNameSpan>
+            さんがコメントしました。&emsp;99分前
+          </StyledCommentInfoP>
+
+          {isYour && (
+            <StyledEllipsisButton onClick={openPopover}>
+              <StyledFontAwesomeIcon icon={faEllipsisH} />
+            </StyledEllipsisButton>
+          )}
+        </StyledCommentInfoRow>
+
+        {!isYour || state === 'view' ? (
+          <StyledCommentText>{chatInfo.comment}</StyledCommentText>
+        ) : (
+          <StyledInputFormField>
+            <StyledFlexTextarea
+              initialVal={chatInfo.comment}
+              {...register('comment', {
+                required: '未入力です',
+                maxLength: { value: 255, message: '255文字以内で入力してください' },
+                pattern: { value: /.*\S+.*/, message: '空白のみのコメントは投稿できません' },
+                validate: value => value !== chatInfo.comment,
+              })}
+            />
+
+            <StyledButtonWrapper>
+              <StyledCancelButton onClick={() => setState('view')}>
+                <StyledCancelText>キャンセル</StyledCancelText>
+              </StyledCancelButton>
+              <CoarseRedOxideButton text="保存" onClick={onClickUpdateButton} disabled={disabled} />
+            </StyledButtonWrapper>
+          </StyledInputFormField>
+        )}
+
+        <SmallPopover
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          handleClose={closePopover}
+          handleEdit={() => setState('edit')}
+          handleRemove={onClickDeleteButton}
+        />
+      </StyledTextWrapper>
+    </StyledCommentWrapper>
   )
 }
+
+const StyledCommentWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`
 
 const StyledTextWrapper = styled.div`
   display: flex;

--- a/frontend/src/components/models/task/TaskCommentArea.tsx
+++ b/frontend/src/components/models/task/TaskCommentArea.tsx
@@ -18,15 +18,12 @@ export const TaskCommentArea: FCX<Props> = ({ className, id }) => {
       <TaskCommentInputField id={id} />
       {!!chatList.length &&
         chatList.map((chat, index) => (
-          <StyledCommentWrapper key={index}>
-            {/* TODO: occupationも取得できるようになったら追加する */}
-            <UserAvatarIcon
-              avatarStyleType="modal"
-              iconImage={chat.user.icon_image}
-              name={chat.user.name}
-            />
-            <TaskComment taskId={id} chatInfo={chat} isYour={judgeIsYourComment(chat.user.id)} />
-          </StyledCommentWrapper>
+          <TaskComment
+            key={index}
+            taskId={id}
+            chatInfo={chat}
+            isYour={judgeIsYourComment(chat.user.id)}
+          />
         ))}
     </StyledAllWrapper>
   )
@@ -37,8 +34,4 @@ const StyledAllWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: ${calculateMinSizeBasedOnFigma(8)};
-`
-const StyledCommentWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
 `

--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -151,15 +151,21 @@ const StyledLeftColumn = styled.div`
   width: ${calculateMinSizeBasedOnFigma(509)};
   height: 100%;
   overflow-x: visible;
-  overflow-y: hidden;
+  overflow-y: scroll;
   will-change: transform;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `
 const StyledRightColumn = styled.div`
   width: ${calculateMinSizeBasedOnFigma(270)};
   height: 100%;
   overflow-x: visible;
-  overflow-y: hidden;
+  overflow-y: scroll;
   will-change: transform;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `
 const StyledLeftColumnInnerContents = styled.div``
 const StyledRightColumnInnerContents = styled.div`

--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -16,7 +16,6 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { useTaskEndDateEditForm } from 'hooks/useTaskEndDateEditForm'
 import { useTaskUserSelectForm } from 'hooks/useTaskUserSelectForm'
 import { useModalInterlockingScroll } from 'hooks/useModalInterlockingScroll'
-import { usePopover } from 'hooks/usePopover'
 import { useDeleteTask } from 'hooks/useDeleteTask'
 import { Task } from 'types/task'
 

--- a/frontend/src/components/models/task/TaskEditOverviewField.tsx
+++ b/frontend/src/components/models/task/TaskEditOverviewField.tsx
@@ -22,7 +22,7 @@ export const TaskEditOverviewField: FCX<Props> = ({ className, id, overview }) =
       <StyledViewWrapper className={className}>
         <StyledH3>概要</StyledH3>
         <StyledClickableArea onClick={() => setState('edit')}>
-          <StyledOverview>{newOverview}</StyledOverview>
+          <StyledOverview>{newOverview || '詳しい説明を追加してください'}</StyledOverview>
           <StyledAnnotation>
             クリックで編集
             <FontAwesomeIcon icon={faPencilAlt} />

--- a/frontend/src/components/ui/avatar/UserAvatarIcon.tsx
+++ b/frontend/src/components/ui/avatar/UserAvatarIcon.tsx
@@ -1,6 +1,7 @@
 import React, { FCX } from 'react'
-import styled, { css } from 'styled-components'
-import { useHover } from 'hooks/useHover'
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
+import { HoverTriggerPopover } from 'components/ui/popup/HoverTriggerPopover'
+import { usePopover } from 'hooks/usePopover'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { AVATAR_STYLE } from 'consts/avatarStyle'
@@ -21,15 +22,26 @@ export const UserAvatarIcon: FCX<Props> = ({
   occupation,
   className,
 }) => {
-  const [hovered, eventHoverHandlers] = useHover()
+  const { anchorEl, openPopover, closePopover } = usePopover()
 
   if (avatarStyleType === AVATAR_STYLE.LIST)
     return (
-      <StyledUserAvatarIconListContainer {...eventHoverHandlers} className={className}>
+      <StyledUserAvatarIconListContainer onMouseEnter={openPopover} className={className}>
         <StyledUserAvatarListIcon iconImage={iconImage} />
 
-        {hovered && (
-          <StyledPopupUserInfoContainer bottom={66}>
+        <HoverTriggerPopover
+          anchorEl={anchorEl}
+          handleClose={closePopover}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}>
+          <StyledDummyListIcon onMouseLeave={closePopover} />
+          <StyledPopupUserInfoContainer>
             <StyledPopupUserIconContainer>
               <img src={iconImage} />
             </StyledPopupUserIconContainer>
@@ -39,7 +51,7 @@ export const UserAvatarIcon: FCX<Props> = ({
               <StyledPopupUserOccupation>{occupation}</StyledPopupUserOccupation>
             </StyledPopupUserContainer>
           </StyledPopupUserInfoContainer>
-        )}
+        </HoverTriggerPopover>
       </StyledUserAvatarIconListContainer>
     )
   else if (avatarStyleType === AVATAR_STYLE.TASK)
@@ -50,7 +62,7 @@ export const UserAvatarIcon: FCX<Props> = ({
     )
   else
     return (
-      <StyledUserAvatarIconModalContainer {...eventHoverHandlers} className={className}>
+      <StyledUserAvatarIconModalContainer onMouseEnter={openPopover} className={className}>
         {onClickDeleteBtn && (
           <StyledUserCloseButton onClick={onClickDeleteBtn}>
             <img src="/svg/avatar-icon_close.svg" alt="バツボタン" />
@@ -58,8 +70,19 @@ export const UserAvatarIcon: FCX<Props> = ({
         )}
         <StyledUserAvatarModalIcon iconImage={iconImage} />
 
-        {hovered && (
-          <StyledPopupUserInfoContainer bottom={66}>
+        <HoverTriggerPopover
+          anchorEl={anchorEl}
+          handleClose={closePopover}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}>
+          <StyledDummyModalIcon onMouseLeave={closePopover} />
+          <StyledPopupUserInfoContainer>
             <StyledPopupUserIconContainer>
               <img src={iconImage} />
             </StyledPopupUserIconContainer>
@@ -69,28 +92,48 @@ export const UserAvatarIcon: FCX<Props> = ({
               <StyledPopupUserOccupation>{occupation}</StyledPopupUserOccupation>
             </StyledPopupUserContainer>
           </StyledPopupUserInfoContainer>
-        )}
+        </HoverTriggerPopover>
       </StyledUserAvatarIconModalContainer>
     )
 }
 
-const StyledUserAvatarIconListContainer = styled.div`
-  position: relative;
+const listContainerAspectCss = css`
   width: ${calculateMinSizeBasedOnFigma(50)};
   height: ${calculateMinSizeBasedOnFigma(50)};
 `
-
-const StyledUserAvatarIconTaskContainer = styled.div`
-  position: relative;
+const taskContainerAspectCss = css`
   width: ${calculateMinSizeBasedOnFigma(24)};
   height: ${calculateMinSizeBasedOnFigma(24)};
 `
-
-const StyledUserAvatarIconModalContainer = styled.div`
-  position: relative;
+const modalContainerAspectCss = css`
   width: ${calculateMinSizeBasedOnFigma(40)};
   height: ${calculateMinSizeBasedOnFigma(40)};
 `
+const getStyleIconContainer = (css: FlattenSimpleInterpolation) => styled.div`
+  position: relative;
+  ${css}
+`
+const getStyleDummyIcon = (css: FlattenSimpleInterpolation) => styled.div`
+  position: relative;
+  bottom: 100%;
+  left: 0;
+  ${css}
+`
+const StyledUserAvatarIconListContainer = getStyleIconContainer(listContainerAspectCss)
+const StyledUserAvatarIconTaskContainer = getStyleIconContainer(taskContainerAspectCss)
+const StyledUserAvatarIconModalContainer = getStyleIconContainer(modalContainerAspectCss)
+const StyledDummyListIcon = getStyleDummyIcon(css`
+  /* バツボタンが押せなくならないようにmargin-topを付与 */
+  margin-top: ${calculateMinSizeBasedOnFigma(10)};
+  width: ${calculateMinSizeBasedOnFigma(50)};
+  height: ${calculateMinSizeBasedOnFigma(40)};
+`)
+const StyledDummyModalIcon = getStyleDummyIcon(css`
+  /* バツボタンが押せなくならないようにmargin-topを付与 */
+  margin-top: ${calculateMinSizeBasedOnFigma(10)};
+  width: ${calculateMinSizeBasedOnFigma(40)};
+  height: ${calculateMinSizeBasedOnFigma(30)};
+`)
 
 const StyledUserCloseButton = styled.button`
   position: absolute;
@@ -135,11 +178,7 @@ const StyledUserAvatarModalIcon = styled.div<{ iconImage: string }>`
   ${userAvatarIconCss}
 `
 
-const StyledPopupUserInfoContainer = styled.div<{ bottom: number }>`
-  z-index: ${({ theme }) => theme.Z_INDEX.POPOVER};
-  position: absolute;
-  bottom: ${({ bottom }) => calculateMinSizeBasedOnFigma(-bottom)};
-  left: -20%;
+const StyledPopupUserInfoContainer = styled.div`
   width: ${calculateMinSizeBasedOnFigma(240)};
   height: ${calculateMinSizeBasedOnFigma(60)};
   box-shadow: 0 0 0 1px ${({ theme }) => theme.COLORS.MINE_SHAFT};

--- a/frontend/src/components/ui/popup/HoverTriggerPopover.tsx
+++ b/frontend/src/components/ui/popup/HoverTriggerPopover.tsx
@@ -1,0 +1,41 @@
+import React, { FCX, ComponentProps } from 'react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { BasicPopover } from 'components/ui/popup/BasicPopover'
+
+type Props = ComponentProps<typeof BasicPopover>
+
+const outerTheme = createTheme({
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          '&.MuiPaper-root': {
+            '&.MuiPaper-elevation': {
+              '&.MuiPaper-rounded': {
+                '&.MuiPaper-elevation8': {
+                  '&.MuiPopover-paper': {
+                    background: 'none',
+                    boxShadow: 'none',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+/**
+ * muiのpopoverを使ってホバーポップオーバーを実装しようとすると、自動的に後ろにoverlayが追加されてしまうため、mouseoverイベントがoverlayに邪魔されて発火しなくなってしまう。  
+ *
+ * そのため、mouseenterする要素内にmouseoverイベントを付与するのではなく、popoverに渡すchildrenの中にmouseoverする要素と同じ位置に表示するダミー要素を追加する必要がる。  
+ *
+ * しかし、ダミー要素の周りに余分な背景や影が追加されてしまうため、それを防止するためのコンポーネント
+ */
+export const HoverTriggerPopover: FCX<Props> = ({ children, ...props }) => (
+  <ThemeProvider theme={outerTheme}>
+    <BasicPopover {...props}>{children}</BasicPopover>
+  </ThemeProvider>
+)

--- a/frontend/src/hooks/useModalInterlockingScroll.ts
+++ b/frontend/src/hooks/useModalInterlockingScroll.ts
@@ -62,6 +62,7 @@ export const useModalInterlockingScroll = (): UseModalInterlockingScrollReturn =
     return innerHeight + scrollableLength
   }, [leftScrollableLength, rightScrollableLength, innerHeight])
 
+  // 連動スクロール本体。overlayがスクロールされたらモーダル内部も連動してスクロールさせる
   useEffect(() => {
     const setWhichWheeled = (e: WheelEvent) => (whichWheeled.current = 'overlay')
     const scrollModal = () => {
@@ -84,17 +85,23 @@ export const useModalInterlockingScroll = (): UseModalInterlockingScrollReturn =
     }
   }, [scrollableRef.current])
 
+  // モーダル内部から直接スクロールするのを禁止して、overlayにスクロールを一任することで連動スクロールを実装
   useEffect(() => {
     const fireOverlayScrollFactory = (which: 'left' | 'right') => {
       return (e: WheelEvent) => {
         whichWheeled.current = which
         e.preventDefault()
-        if (scrollableRef.current) scrollableRef.current.scrollTop += e.deltaY * 0.8
+        if (scrollableRef.current) {
+          const SCROLL_PER_DELTA = 0.8
+          scrollableRef.current.scrollTop += e.deltaY * SCROLL_PER_DELTA
+        }
       }
     }
     const fireOverlayScrollAtLeft = fireOverlayScrollFactory('left')
     const fireOverlayScrollAtRight = fireOverlayScrollFactory('right')
     const preventScroll = (e: Event) => {
+      // 常にpreventDefaultしているとスクロールがカクつくので、モーダル内部でのスクロールのみ禁止
+      // イベントは wheel -> scroll の順で発生するので, whichWheeledによる分岐がちゃんと働く
       if (whichWheeled.current !== 'overlay') e.preventDefault()
     }
 

--- a/frontend/src/hooks/useModalInterlockingScroll.ts
+++ b/frontend/src/hooks/useModalInterlockingScroll.ts
@@ -26,6 +26,7 @@ type UseModalInterlockingScrollReturn = {
 export const useModalInterlockingScroll = (): UseModalInterlockingScrollReturn => {
   const { innerHeight } = useWatchInnerAspect()
   const scrollableRef = useRef<HTMLDivElement>(null)
+  const preScrollTop = useRef<number>(0)
   const [leftColumnHeight, setLeftColumnHeight] = useState<number>(0)
   const [rightColumnHeight, setRightColumnHeight] = useState<number>(0)
   const [leftColumnInnerHeight, setLeftColumnInnerHeight] = useState<number>(0)
@@ -63,8 +64,12 @@ export const useModalInterlockingScroll = (): UseModalInterlockingScrollReturn =
     const scrollModal = () => {
       if (!scrollableRef.current || !leftColumnRef.current || !rightColumnRef.current) return
       const scrollTop = scrollableRef.current.scrollTop
-      leftColumnRef.current.scrollTop = scrollTop
-      rightColumnRef.current.scrollTop = scrollTop
+      const scrollDiff = scrollTop - preScrollTop.current
+
+      leftColumnRef.current.scrollTop += scrollDiff
+      rightColumnRef.current.scrollTop += scrollDiff
+
+      preScrollTop.current = scrollTop
     }
 
     scrollableRef.current?.addEventListener('scroll', scrollModal, { passive: true })


### PR DESCRIPTION
## 実装の概要
- ユーザーのポップオーバーがモーダルからはみ出る時に切れてしまう問題の修正
  - Material UIを使用して `HoverTriggerPopover` を作成した
- 連動スクロールの完成
- 概要未入力時は「詳しい説明を追加してください」と表示
- コメントが入力されている状態で編集をすると、最初の高さが小さい問題の修正

<!-- 概要を入力 -->

Closes #134

## 目的
タスク編集モーダルの連動スクロールを追加して完成させる

## レビューして欲しいところ
- `useModalInterlockingScroll` の中身が直感的に分かりづらいコードになってしまった
  - コメントアウトを追加して努力はしたが、まだわからない部分や、説明変数を挟んだ方がいい部分があれば指摘してほしい

## 関連
#198 
#214 

## 今後のタスク
- 細かい修正（issue化しておく）
  - リロード後に最初に開いたタスクのユーザー数、ステータスポイントが他のタスクに移っても変わらない不具合の修正
  - 完了にあるタスクだけアサインを動かせないようにする 
  - コメントの入力状態をキャッシュする
  - 連打防止処理の追加
- アカウント設定モーダル引き継ぐ