### PR TITLE
fix: コメントでユーザーホバー時に職業表示, 完了にあるタスクはアサインを動かせなくする

### DIFF
--- a/frontend/src/components/models/task/TaskComment.tsx
+++ b/frontend/src/components/models/task/TaskComment.tsx
@@ -30,11 +30,11 @@ export const TaskComment: FCX<Props> = ({ taskId, chatInfo, isYour }) => {
 
   return (
     <StyledCommentWrapper>
-      {/* TODO: occupationも取得できるようになったら追加する */}
       <UserAvatarIcon
         avatarStyleType="modal"
         iconImage={chatInfo.user.icon_image}
         name={chatInfo.user.name}
+        occupation={chatInfo.user.occupation.name}
       />
 
       <StyledTextWrapper>

--- a/frontend/src/components/models/task/TaskCommentArea.tsx
+++ b/frontend/src/components/models/task/TaskCommentArea.tsx
@@ -1,7 +1,6 @@
 import React, { FCX } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { TaskCommentInputField } from 'components/models/task/TaskCommentInputField'
-import { UserAvatarIcon } from 'components/ui/avatar/UserAvatarIcon'
 import { TaskComment } from 'components/models/task/TaskComment'
 import { useShowChats } from 'hooks/useShowChats'
 import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'

--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -39,6 +39,7 @@ export const TaskEditModal: FCX<Props> = ({
   motivation,
   design,
   plan,
+  completed_flg,
 }) => {
   const { onChange, register } = useTaskEndDateEditForm({
     id,
@@ -87,6 +88,7 @@ export const TaskEditModal: FCX<Props> = ({
                 setUserData={setUserData}
                 userData={userData}
                 taskModalType="edit"
+                completed_flag={completed_flg}
               />
               <StyledTaskEditStatusPointField
                 id={id}

--- a/frontend/src/components/ui/form/SearchMemberField.tsx
+++ b/frontend/src/components/ui/form/SearchMemberField.tsx
@@ -9,11 +9,13 @@ import { UserAvatarIcon } from 'components/ui/avatar/UserAvatarIcon'
 import { UserCount } from 'components/ui/avatar/UserCount'
 import type { UserData } from 'types/userData'
 import type { TaskModalType } from 'types/taskModal'
+import type { Task } from 'types/task'
 
 type Props = {
   setUserData: Dispatch<SetStateAction<UserData>>
   userData: UserData
   taskModalType: TaskModalType
+  completed_flag?: Task['completed_flg']
 }
 
 export const SearchMemberField: FCX<Props> = ({
@@ -21,6 +23,7 @@ export const SearchMemberField: FCX<Props> = ({
   setUserData,
   userData,
   taskModalType,
+  completed_flag = false,
 }) => {
   const {
     onChange,
@@ -57,6 +60,7 @@ export const SearchMemberField: FCX<Props> = ({
           type="text"
           placeholder="パーティメンバーを検索"
           value={value}
+          disabled={completed_flag}
           onChange={onChange}
           onFocus={onFocus}
           onBlur={onBlur}
@@ -96,13 +100,12 @@ export const SearchMemberField: FCX<Props> = ({
               if (boxCount < maxBoxes) {
                 return (
                   <div key={index} ref={avatarRef}>
-                    {/* TODO: queryでoccupation_idから職業が取れるようになったらそっちを使うようにする */}
                     <UserAvatarIcon
                       avatarStyleType={AVATAR_STYLE.MODAL}
                       iconImage={data.icon_image}
                       name={data.name}
                       occupation={data.occupation.name}
-                      onClickDeleteBtn={() => onClickDeleteBtn(index)}
+                      onClickDeleteBtn={completed_flag ? undefined : () => onClickDeleteBtn(index)}
                     />
                   </div>
                 )
@@ -113,7 +116,7 @@ export const SearchMemberField: FCX<Props> = ({
                       avatarStyleType={AVATAR_STYLE.MODAL}
                       userCount={overUsersCount}
                       userData={selectedUserData}
-                      onClickDeleteBtn={onClickDeleteBtn}
+                      onClickDeleteBtn={completed_flag ? undefined : onClickDeleteBtn}
                     />
                   </div>
                 )
@@ -150,17 +153,24 @@ const StyledInputWrapper = styled.div`
     background-size: 100% 100%;
   }
 `
-const StyledInput = styled.input`
+const StyledInput = styled.input<{ disabled: boolean }>`
   width: 100%;
   height: ${calculateMinSizeBasedOnFigma(40)};
   padding-left: ${calculateMinSizeBasedOnFigma(8)};
   padding-right: ${calculateMinSizeBasedOnFigma(8)};
-  border: solid 1px ${({ theme }) => convertIntoRGBA(theme.COLORS.MONDO, 0.6)};
   border-radius: 4px;
-  font-size: ${({ theme }) => theme.FONT_SIZES.SIZE_14};
-  &::placeholder {
-    color: ${({ theme }) => theme.COLORS.SILVER};
-  }
+  ${({ theme, disabled }) =>
+    css`
+      ${disabled &&
+      css`
+        cursor: not-allowed;
+      `}
+      border: solid 1px ${convertIntoRGBA(theme.COLORS.MONDO, 0.6)};
+      font-size: ${theme.FONT_SIZES.SIZE_14};
+      &::placeholder {
+        color: ${theme.COLORS.SILVER};
+      }
+    `}
 `
 const StyledSearchResultWrapper = styled.ul`
   z-index: ${({ theme }) => theme.Z_INDEX.INDEX_3};

--- a/frontend/src/components/ui/popup/SearchTaskPopup.tsx
+++ b/frontend/src/components/ui/popup/SearchTaskPopup.tsx
@@ -58,6 +58,7 @@ export const SearchTaskPopup: FCX<Props> = ({ className, searchedTasks }) => {
                           chatCount={task.chatCount}
                           end_date={task.end_date}
                           overview={task.overview}
+                          completed_flg={task.completed_flg}
                         />
                       </div>
                     ))}

--- a/frontend/src/pages/projectDetail/ProjectDetail.tsx
+++ b/frontend/src/pages/projectDetail/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useLayoutEffect } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { DropResult, resetServerContext } from 'react-beautiful-dnd'
 import styled, { css } from 'styled-components'
@@ -7,7 +7,6 @@ import { useGetCurrentUserLazyQuery } from './getUser.gen'
 import { useSearchSameCompanyUsersMutation } from '../projectList/projectList.gen'
 import {
   useGetProjectLazyQuery,
-  useUpdateOnlineFlagMutation,
   useCreateInvitationMutation,
   useUpdateTaskSortMutation,
   useCreateListMutation,
@@ -84,6 +83,7 @@ export const ProjectDetail: FC = () => {
             vertical_sort: task.vertical_sort,
             end_date: task.end_date,
             chatCount: task.chatCount,
+            completed_flg: task.completed_flg,
             allocations,
           }
         })
@@ -174,6 +174,7 @@ export const ProjectDetail: FC = () => {
           vertical_sort: task.vertical_sort,
           end_date: task.end_date,
           chatCount: task.chatCount,
+          completed_flg: task.completed_flg,
           allocations,
         }
       })

--- a/frontend/src/pages/projectDetail/projectDetail.gql
+++ b/frontend/src/pages/projectDetail/projectDetail.gql
@@ -332,10 +332,10 @@ query GetChats($taskId: Float!) {
       id
       name
       icon_image
-      # occupation {
-      #   id
-      #   name
-      # }
+      occupation {
+        id
+        name
+      }
     }
     created_at
     updated_at
@@ -350,10 +350,10 @@ mutation AddChat($taskId: Float!, $userId: String!, $comment: String!) {
       id
       name
       icon_image
-      # occupation {
-      #   id
-      #   name
-      # }
+      occupation {
+        id
+        name
+      }
     }
     created_at
     updated_at
@@ -368,10 +368,10 @@ mutation UpdateChat($taskId: Float!, $chatId: Float!, $comment: String!) {
       id
       name
       icon_image
-      # occupation {
-      #   id
-      #   name
-      # }
+      occupation {
+        id
+        name
+      }
     }
     created_at
     updated_at
@@ -386,10 +386,10 @@ mutation DeleteChat($taskId: Float!, $chatId: Float!) {
       id
       name
       icon_image
-      # occupation {
-      #   id
-      #   name
-      # }
+      occupation {
+        id
+        name
+      }
     }
     created_at
     updated_at

--- a/frontend/src/pages/projectDetail/projectDetail.gql
+++ b/frontend/src/pages/projectDetail/projectDetail.gql
@@ -291,6 +291,7 @@ mutation CreateList($newList: NewListInput!) {
       vertical_sort
       end_date
       chatCount
+      completed_flg
 
       allocations {
         id

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -5,7 +5,7 @@ export type Allocation =
 
 export type Task = Omit<
   GetProjectQuery['getProjectById']['lists'][number]['tasks'][number],
-  'allocations' | 'completed_flg'
+  'allocations'
 > & {
   allocations: Allocation[]
 }


### PR DESCRIPTION
## 実装の概要
- コメントでユーザーホバー時に職業表示
- 完了にあるタスクはアサインを動かせなくする

<!-- 概要を入力 -->

Trello #229 #230 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #229 #230 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク
#227
#208
#183

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
