### PR TITLE
add: タスクモーダル表示時の右のスクロールバーを装飾

### DIFF
--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -157,7 +157,7 @@ const StyledLeftColumn = styled.div`
   overflow-x: visible;
   overflow-y: scroll;
   will-change: transform;
-  ::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     display: none;
   }
 `
@@ -167,7 +167,7 @@ const StyledRightColumn = styled.div`
   overflow-x: visible;
   overflow-y: scroll;
   will-change: transform;
-  ::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     display: none;
   }
 `
@@ -248,6 +248,24 @@ const StyledScrollableOverlay = styled.div`
   overflow-y: scroll;
   will-change: transform;
   background-color: transparent;
+
+  ${({ theme }) =>
+    css`
+      &::-webkit-scrollbar {
+        width: 12px;
+        background-color: #f5f5f5;
+      }
+      &::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 6px ${convertIntoRGBA(theme.COLORS.BLACK, 0.3)};
+        border-radius: 10px;
+        background-color: #f5f5f5;
+      }
+      &::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        -webkit-box-shadow: inset 0 0 6px ${convertIntoRGBA(theme.COLORS.BLACK, 0.3)};
+        background-color: ${theme.COLORS.MINE_SHAFT};
+      }
+    `}
 `
 const StyledScrollableDummy = styled.div<{ height: number }>`
   width: 100%;


### PR DESCRIPTION
## 実装の概要
- タスクモーダル表示時の右のスクロールバーを装飾
  - 目立たせたいけど、あまり目立ちすぎてもおかしいので控えめな色にした
  - widthはやや広めにとった

Trello #227 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #227 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## レビューして欲しいところ
- スクロールバーの色がこれでいいかどうか
  - 気に食わなかったらpullして適当に色とか幅とか変えてほしい!

https://user-images.githubusercontent.com/47961006/146391137-04d4be9c-a209-4d52-abbe-b8b71c1a1b79.mov


## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク
#208
#183

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
