### PR TITLE
タスクカードの日付が潰れる問題を修正

### DIFF
--- a/frontend/src/components/models/project/ProjectDrawer.tsx
+++ b/frontend/src/components/models/project/ProjectDrawer.tsx
@@ -84,10 +84,10 @@ const StyledMainWrap = styled.div<{ isOpen: boolean }>`
   ${({ isOpen }) =>
     isOpen
       ? css`
-          width: ${calculateVwBasedOnFigma(920)};
+          width: ${calculateVwBasedOnFigma(946)};
         `
       : css`
-          width: ${calculateVwBasedOnFigma(1160)};
+          width: ${calculateVwBasedOnFigma(1156)};
         `}
 `
 const StyledDrawer = {

--- a/frontend/src/components/models/task/TaskCard.tsx
+++ b/frontend/src/components/models/task/TaskCard.tsx
@@ -200,7 +200,7 @@ const StyledAvatarContainer = styled.div`
 `
 const StyledCommentContainer = styled.div`
   display: flex;
-  gap: ${calculateMinSizeBasedOnFigma(4)};
+  gap: ${calculateMinSizeBasedOnFigma(2)};
   align-items: center;
 `
 const StyledFootContainer = styled.div`

--- a/frontend/src/components/models/task/TaskCard.tsx
+++ b/frontend/src/components/models/task/TaskCard.tsx
@@ -193,6 +193,7 @@ const StyledFlexContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  flex-wrap: wrap;
 `
 const StyledAvatarContainer = styled.div`
   display: flex;

--- a/frontend/src/components/models/task/TaskColumn.tsx
+++ b/frontend/src/components/models/task/TaskColumn.tsx
@@ -155,7 +155,7 @@ export const TaskColumn: FCX<Props> = ({ id, list_id, title, tasks, listIndex, l
 
 const StyledColumnContainer = styled.ul`
   position: relative;
-  width: ${calculateMinSizeBasedOnFigma(270)};
+  width: ${calculateMinSizeBasedOnFigma(280)};
   min-height: ${calculateMinSizeBasedOnFigma(206)};
   border: 1px solid ${convertIntoRGBA(theme.COLORS.MONDO, 0.6)};
   border-radius: 3px;

--- a/frontend/src/components/ui/loading/Loading.tsx
+++ b/frontend/src/components/ui/loading/Loading.tsx
@@ -11,6 +11,8 @@ export const Loading: FCX = () => {
       renderer: 'svg',
       animationData: JSON.parse(JSON.stringify(nowLoading)),
     })
+
+    return () => lottie.stop()
   }, [])
 
   return (


### PR DESCRIPTION
## 実装の概要

スクロールバー分カードが小さくなるのが原因
widthを伸ばすことで解決

Trello #237 
Closes #237

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
