### PR TITLE
add: 検索結果のタスクを押下したときにモーダルを表示できるようにした #240

### DIFF
--- a/frontend/src/components/ui/popup/SearchTaskPopup.tsx
+++ b/frontend/src/components/ui/popup/SearchTaskPopup.tsx
@@ -3,7 +3,8 @@ import styled, { css } from 'styled-components'
 import { SearchTask } from 'types/task'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
-import { TaskCardPopup } from './TaskCardPopup'
+import { TaskCardPopup } from 'components/ui/popup/TaskCardPopup'
+import { TaskEditModal } from 'components/models/task/TaskEditModal'
 
 type Props = {
   searchedTasks: SearchTask[]
@@ -12,6 +13,7 @@ type Props = {
 // TODO: モーダルが出来次第、タスクモーダルが開く処理をかく
 export const SearchTaskPopup: FCX<Props> = ({ className, searchedTasks }) => {
   const [isTask, setIsTask] = useState(false)
+  const [shouldShowModal, setShouldShowModal] = useState<boolean>(false)
 
   useEffect(() => {
     setIsTask(false)
@@ -46,6 +48,7 @@ export const SearchTaskPopup: FCX<Props> = ({ className, searchedTasks }) => {
                     {searchedTask.tasks.map((task, index) => (
                       <div key={index}>
                         <TaskCardPopup
+                          openModal={() => setShouldShowModal(true)}
                           title={task.title}
                           technology={task.technology}
                           achievement={task.achievement}
@@ -59,6 +62,12 @@ export const SearchTaskPopup: FCX<Props> = ({ className, searchedTasks }) => {
                           end_date={task.end_date}
                           overview={task.overview}
                           completed_flg={task.completed_flg}
+                        />
+
+                        <TaskEditModal
+                          {...task}
+                          shouldShow={shouldShowModal}
+                          setShouldShow={setShouldShowModal}
                         />
                       </div>
                     ))}

--- a/frontend/src/components/ui/popup/TaskCardPopup.tsx
+++ b/frontend/src/components/ui/popup/TaskCardPopup.tsx
@@ -2,22 +2,20 @@ import React, { FCX } from 'react'
 import { Task } from 'types/task'
 import { Params } from 'types/status'
 import { calculateMinSizeBasedOnFigmaWidth } from 'utils/calculateSizeBasedOnFigma'
-import { changeWeaponImage } from 'utils/changeWeaponImage'
 import { changeDeadlineImage } from 'utils/changeDeadlineImage'
-import { UserAvatarIcon } from 'components/ui/avatar/UserAvatarIcon'
-import { UserCount } from 'components/ui/avatar/UserCount'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faComment } from '@fortawesome/free-regular-svg-icons'
-import { AVATAR_STYLE } from 'consts/avatarStyle'
 import date from 'utils/date/date'
 import styled, { css } from 'styled-components'
 
 type Props = {
   listIndex: number
   listLength: number
+  openModal: () => void
 } & Omit<Task, 'vertical_sort' | 'id' | 'allocations'>
 
 export const TaskCardPopup: FCX<Props> = ({
+  openModal,
   title,
   technology,
   achievement,
@@ -40,7 +38,7 @@ export const TaskCardPopup: FCX<Props> = ({
   ]
 
   return (
-    <StyledContainer>
+    <StyledContainer onClick={openModal}>
       <StyledInnerWrap>
         <StyledTitle>{title}</StyledTitle>
         <StyledFlexContainer>
@@ -73,6 +71,7 @@ export const TaskCardPopup: FCX<Props> = ({
 }
 
 const StyledContainer = styled.div`
+  cursor: pointer;
   height: auto;
   padding: ${calculateMinSizeBasedOnFigmaWidth(2)};
   border: 1px solid ${({ theme }) => theme.COLORS.GRAY};


### PR DESCRIPTION
## 実装の概要
検索結果のタスクを押下したときにモーダルを表示できるようにした

<!-- 概要を入力 -->

Trello #240 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #240 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
