### PR TITLE
fix: ユーザごとにステータスを振り分けるように

### DIFF
--- a/api/src/tasks/tasks.service.ts
+++ b/api/src/tasks/tasks.service.ts
@@ -113,6 +113,12 @@ export class TasksService {
           }
 
           user.exp = sumExp;
+          user.technology += task.technology;
+          user.achievement += task.achievement;
+          user.solution += task.solution;
+          user.motivation += task.motivation;
+          user.design += task.design;
+          user.plan += task.plan;
           await this.userRepository.save(user).catch((err) => {
             throw err;
           });
@@ -139,6 +145,12 @@ export class TasksService {
           if (!user) throw new NotFoundException();
 
           user.exp -= totalStatus;
+          user.technology -= task.technology;
+          user.achievement -= task.achievement;
+          user.solution -= task.solution;
+          user.motivation -= task.motivation;
+          user.design -= task.design;
+          user.plan -= task.plan;
           await this.userRepository.save(user).catch((err) => {
             throw err;
           });


### PR DESCRIPTION
## 実装の概要
タスクを完了リストに移動した時にステータスポイントがユーザに振り分けらるように(忘れてました！)

Trello #257
Closes #257

## 目的
完了リストに移動した時にステータスが振られるように

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
