### PR TITLE
fix: プロジェクト一覧画面のスタイリングを修正

### DIFF
--- a/frontend/src/components/ui/wrapper/ContentWrapper.tsx
+++ b/frontend/src/components/ui/wrapper/ContentWrapper.tsx
@@ -24,7 +24,7 @@ const StyledBackground = styled.div`
   background-color: ${({ theme }) => theme.COLORS.BLACK};
 `
 const Wrapper = styled.div`
-  overflow: hidden;
+  overflow-x: clip;
   margin: 0 auto;
   max-width: ${({ theme }) => theme.MAX_WIDTH};
   height: 100%;

--- a/frontend/src/pages/projectList/ProjectList.tsx
+++ b/frontend/src/pages/projectList/ProjectList.tsx
@@ -5,7 +5,6 @@ import { Notifications } from 'types/notification'
 import { DEFAULT_USER } from 'consts/defaultImages'
 import { useAuthContext } from 'providers/AuthProvider'
 import { useUsersLazyQuery } from './projectList.gen'
-import { ContentWrapper } from 'components/ui/wrapper/ContentWrapper'
 import { ProjectListHeader } from 'components/ui/header/ProjectListHeader'
 import { ProjectListCreateModal } from 'components/models/projectList/ProjectListCreateModal'
 import {
@@ -50,64 +49,62 @@ export const ProjectList: FC = () => {
   return (
     <>
       <LazyLoading />
-      <ContentWrapper>
-        <ProjectListHeader
-          iconImage={userData.data?.user.icon_image ?? DEFAULT_USER}
-          name={userData.data?.user.name ?? ''}
-          uid={userData.data?.user.id ?? ''}
-          totalExp={userData.data?.user.exp ?? 0}
-          notifications={notifications}
+      <ProjectListHeader
+        iconImage={userData.data?.user.icon_image ?? DEFAULT_USER}
+        name={userData.data?.user.name ?? ''}
+        uid={userData.data?.user.id ?? ''}
+        totalExp={userData.data?.user.exp ?? 0}
+        notifications={notifications}
+      />
+
+      <StyledProjectListPageContainer>
+        <StyledProjectListContainer>
+          <StyledProjectTitleWrapper>
+            <StyledProjectTitle>プロジェクト一覧</StyledProjectTitle>
+          </StyledProjectTitleWrapper>
+          <StyledProjectListBodyWrapper>
+            <StyledCreateProjectButton>
+              <ComplicateButton
+                buttonColorType={BUTTON_COLOR_TYPE.YELLOW}
+                text="プロジェクト作成"
+                onClick={() => setShouldShowModal(true)}
+              />
+            </StyledCreateProjectButton>
+
+            <StyledProjectListScroll>
+              <StyledProjectList>
+                {userData.data?.user.groups.map((group, index) => (
+                  <StyledProject key={index} onClick={() => setSelectProject(index)}>
+                    <ProjectListItem
+                      activeStatue={
+                        index === selectProject ? ACTIVE_STATUS.ACTIVE : ACTIVE_STATUS.NOT_ACTIVE
+                      }
+                      isEnd={group.project.project_end_flg}
+                      projectTitle={group.project.name}
+                      startDate={group.project.created_at}
+                      endDate={group.project.end_date}
+                    />
+                  </StyledProject>
+                ))}
+              </StyledProjectList>
+            </StyledProjectListScroll>
+          </StyledProjectListBodyWrapper>
+        </StyledProjectListContainer>
+
+        <StyledProjectListDetail
+          isJoiningProject={!!userData.data?.user.groups.length}
+          userQuery={userData.data}
+          selectProject={selectProject}
+          openModal={() => setShouldShowModal(true)}
         />
 
-        <StyledProjectListPageContainer>
-          <StyledProjectListContainer>
-            <StyledProjectTitleWrapper>
-              <StyledProjectTitle>プロジェクト一覧</StyledProjectTitle>
-            </StyledProjectTitleWrapper>
-            <StyledProjectListBodyWrapper>
-              <StyledCreateProjectButton>
-                <ComplicateButton
-                  buttonColorType={BUTTON_COLOR_TYPE.YELLOW}
-                  text="プロジェクト作成"
-                  onClick={() => setShouldShowModal(true)}
-                />
-              </StyledCreateProjectButton>
+        <StyledProjectListBackground />
+      </StyledProjectListPageContainer>
 
-              <StyledProjectListScroll>
-                <StyledProjectList>
-                  {userData.data?.user.groups.map((group, index) => (
-                    <StyledProject key={index} onClick={() => setSelectProject(index)}>
-                      <ProjectListItem
-                        activeStatue={
-                          index === selectProject ? ACTIVE_STATUS.ACTIVE : ACTIVE_STATUS.NOT_ACTIVE
-                        }
-                        isEnd={group.project.project_end_flg}
-                        projectTitle={group.project.name}
-                        startDate={group.project.created_at}
-                        endDate={group.project.end_date}
-                      />
-                    </StyledProject>
-                  ))}
-                </StyledProjectList>
-              </StyledProjectListScroll>
-            </StyledProjectListBodyWrapper>
-          </StyledProjectListContainer>
-
-          <StyledProjectListDetail
-            isJoiningProject={!!userData.data?.user.groups.length}
-            userQuery={userData.data}
-            selectProject={selectProject}
-            openModal={() => setShouldShowModal(true)}
-          />
-
-          <StyledProjectListBackground />
-        </StyledProjectListPageContainer>
-
-        <ProjectListCreateModal
-          shouldShow={shouldShowModal}
-          closeModal={() => setShouldShowModal(false)}
-        />
-      </ContentWrapper>
+      <ProjectListCreateModal
+        shouldShow={shouldShowModal}
+        closeModal={() => setShouldShowModal(false)}
+      />
     </>
   )
 }

--- a/frontend/src/pages/projectList/ProjectList.tsx
+++ b/frontend/src/pages/projectList/ProjectList.tsx
@@ -164,10 +164,13 @@ const StyledProjectTitle = styled.p`
     `}
 `
 
-const padding = `${calculateVhBasedOnFigma(64)} ${calculateMinSizeBasedOnFigmaWidth(
+const projectListBodyPaddingTop = calculateVhBasedOnFigma(64)
+const projectListBodyPaddingBottom = calculateVhBasedOnFigma(38)
+const padding = `${projectListBodyPaddingTop} ${calculateMinSizeBasedOnFigmaWidth(
   9,
-)} ${calculateVhBasedOnFigma(38)} 0` // ts-styled-pluginエラーを避けるため
+)} ${projectListBodyPaddingBottom} 0` // ts-styled-pluginエラーを避けるため
 const StyledProjectListBodyWrapper = styled.div`
+  position: relative;
   margin-top: ${calculateVhBasedOnFigma(-22)};
   padding: ${padding};
   width: ${projectListBodyWidth};
@@ -187,15 +190,19 @@ const StyledCreateProjectButton = styled.div`
 
 const StyledScrollWrapper = styled.div`
   overflow-x: visible;
+  position: relative;
   margin-left: ${calculateMinSizeBasedOnFigmaWidth(15)};
   width: ${calculateMinSizeBasedOnFigmaWidth(439)};
+  height: 100%;
 `
 
 const StyledProjectListScroll = styled.div`
   position: relative;
   display: flex;
+  flex-direction: row-reverse;
   overflow-y: scroll;
-  height: 100%;
+  direction: rtl; // スクロールバーを左側に表示する
+  height: calc(100% - (${projectListBodyPaddingTop} + ${projectListBodyPaddingBottom}));
 `
 
 const StyledProjectList = styled.ul`

--- a/frontend/src/pages/projectList/ProjectList.tsx
+++ b/frontend/src/pages/projectList/ProjectList.tsx
@@ -71,23 +71,25 @@ export const ProjectList: FC = () => {
               />
             </StyledCreateProjectButton>
 
-            <StyledProjectListScroll>
-              <StyledProjectList>
-                {userData.data?.user.groups.map((group, index) => (
-                  <StyledProject key={index} onClick={() => setSelectProject(index)}>
-                    <ProjectListItem
-                      activeStatue={
-                        index === selectProject ? ACTIVE_STATUS.ACTIVE : ACTIVE_STATUS.NOT_ACTIVE
-                      }
-                      isEnd={group.project.project_end_flg}
-                      projectTitle={group.project.name}
-                      startDate={group.project.created_at}
-                      endDate={group.project.end_date}
-                    />
-                  </StyledProject>
-                ))}
-              </StyledProjectList>
-            </StyledProjectListScroll>
+            <StyledScrollWrapper>
+              <StyledProjectListScroll>
+                <StyledProjectList>
+                  {userData.data?.user.groups.map((group, index) => (
+                    <StyledProject key={index} onClick={() => setSelectProject(index)}>
+                      <ProjectListItem
+                        activeStatue={
+                          index === selectProject ? ACTIVE_STATUS.ACTIVE : ACTIVE_STATUS.NOT_ACTIVE
+                        }
+                        isEnd={group.project.project_end_flg}
+                        projectTitle={group.project.name}
+                        startDate={group.project.created_at}
+                        endDate={group.project.end_date}
+                      />
+                    </StyledProject>
+                  ))}
+                </StyledProjectList>
+              </StyledProjectListScroll>
+            </StyledScrollWrapper>
           </StyledProjectListBodyWrapper>
         </StyledProjectListContainer>
 
@@ -183,11 +185,16 @@ const StyledCreateProjectButton = styled.div`
   margin-bottom: ${calculateVhBasedOnFigma(24)};
 `
 
+const StyledScrollWrapper = styled.div`
+  overflow-x: visible;
+  margin-left: ${calculateMinSizeBasedOnFigmaWidth(15)};
+  width: ${calculateMinSizeBasedOnFigmaWidth(439)};
+`
+
 const StyledProjectListScroll = styled.div`
+  position: relative;
   display: flex;
-  justify-content: center;
   overflow-y: scroll;
-  direction: rtl;
   height: 100%;
 `
 


### PR DESCRIPTION
## 実装の概要
- プロジェクト一覧画面で画面下部に黒い余白ができてしまう問題の修正
- プロジェクト数が多い時にリストの外にアイテムが飛び出してしまう問題の修正
- プロジェクトのリストアイテムの右側が見切れてしまう問題の修正

![スクリーンショット 2021-12-22 20 54 37](https://user-images.githubusercontent.com/47961006/147089100-5bc5dc02-67f4-4595-b4f5-eb253684e013.png)

Trello #267 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #267 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的
プロジェクト一覧のスタイリングの不具合を修正

## レビューして欲しいところ

## 不安に思っていること
プロジェクト一覧画面で画面下部に5pxほどの白い余白ができており、謎スクロールができてしまう
ContentWrapperが関係あるかもと思ったが全く関係なく、html以下の要素が全て100vh未満であっても発生する
解決策が全くわからなく原因も不明だったことと、大して気にならないたと判断して放置した

issueにした方がいいかなぁ？無視してもいい？？？

https://user-images.githubusercontent.com/47961006/147089279-919325b5-15c2-4ec4-b433-557ba175ce20.mov


## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク
#262
<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
