### PR TITLE
fix: format distance chat message

### DIFF
--- a/frontend/src/components/models/task/TaskComment.tsx
+++ b/frontend/src/components/models/task/TaskComment.tsx
@@ -13,6 +13,7 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 
 import type { Chat } from 'types/chat'
+import date from 'utils/date/date'
 
 type Props = {
   taskId: string
@@ -42,7 +43,7 @@ export const TaskComment: FCX<Props> = ({ taskId, chatInfo, isYour }) => {
         <StyledCommentInfoRow>
           <StyledCommentInfoP>
             <StyledUserNameSpan>{chatInfo.user.name}</StyledUserNameSpan>
-            さんがコメントしました。&emsp;99分前
+            さんがコメントしました。&emsp;{date.formatDistance(chatInfo.updated_at)}
           </StyledCommentInfoP>
 
           {isYour && (

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -1,6 +1,7 @@
 import { isAfter, formatDistanceToNow, differenceInDays, format } from 'date-fns'
 
 import ja from 'date-fns/locale/ja'
+import logger from 'utils/debugger/logger'
 
 type PropsDate = Date | string | number
 
@@ -42,7 +43,10 @@ export default class date {
    * @memberof date
    */
   public static formatDistance = (date: PropsDate): string => {
-    return formatDistanceToNow(new Date(date), { locale: ja })
+    // BUG: データベースから取得した日付にタイムゾーンを適応して、日本との時間の差９時間を足してしまう
+    const utcDate = new Date(date)
+    const jstDate = utcDate.toLocaleString('ja-JP', { timeZone: 'Europe/London' })
+    return formatDistanceToNow(new Date(jstDate), { locale: ja })
   }
 
   /**

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -46,7 +46,7 @@ export default class date {
     // BUG: データベースから取得した日付にタイムゾーンを適応して、日本との時間の差９時間を足してしまう
     const utcDate = new Date(date)
     const jstDate = utcDate.toLocaleString('ja-JP', { timeZone: 'Europe/London' })
-    return formatDistanceToNow(new Date(jstDate), { locale: ja })
+    return formatDistanceToNow(new Date(jstDate), { addSuffix: true, locale: ja })
   }
 
   /**


### PR DESCRIPTION
## 実装の概要
コメントしたの時間を表示

Trello #228
Closes #228

## 目的

## レビューして欲しいところ

## 不安に思っていること
- データベースから取得した日付にタイムゾーンを適応して、日本との時間の差９時間を足してしまう

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連
[date-fnsで「○分前」「約○時間前」「○日前」など現在時刻からのざっくりした時間経過を表示する](https://yucatio.hatenablog.com/entry/2019/12/09/084010)

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
