### PR TITLE
fix: プロジェクト作成の概要のエラーが表示されない問題の修正

### DIFF
--- a/frontend/src/components/models/projectList/ProjectListCreateModal.tsx
+++ b/frontend/src/components/models/projectList/ProjectListCreateModal.tsx
@@ -61,6 +61,7 @@ export const ProjectListCreateModal: FCX<Props> = ({ shouldShow, closeModal, cla
                 maxLength: { value: 255, message: '255文字以内で入力してください' },
               })}
               required={false}
+              error={errors['overview']}
             />
           </StyledLeftColumn>
 

--- a/frontend/src/components/ui/form/TextAreaField.tsx
+++ b/frontend/src/components/ui/form/TextAreaField.tsx
@@ -71,6 +71,7 @@ const StyledTextareaWrapper = styled.div<{ shouldShowError: boolean; errorColor:
   position: relative;
   margin-top: ${calculateMinSizeBasedOnFigma(4)};
   textarea {
+    resize: none;
     padding: ${calculateMinSizeBasedOnFigma(9.24)} ${calculateMinSizeBasedOnFigma(8)};
     border-color: ${props => (props.shouldShowError ? props.errorColor : undefined)} !important;
   }


### PR DESCRIPTION
## 実装の概要
- 概要の文字数が多い時にエラーを表示
- テキストエリアを動かせないようにした

<!-- 概要を入力 -->

Trello #288 #290 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #288 #290 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

![スクリーンショット 2021-12-25 3 42 31](https://user-images.githubusercontent.com/47961006/147369177-0f75bd69-5e9d-47c9-a4b1-cae859505566.png)

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
