### PR TITLE
improve: モーダルの初回のカクつきを若干減らした

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -73,8 +73,8 @@
       href="https://fonts.googleapis.com/css2?family=Yrsa:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="preload" href="'%PUBLIC_URL%/images/project-detail_background.webp'" as="image" />
-    <link rel="preload" href="'%PUBLIC_URL%/images/project-list-page_background.webp'" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/images/project-detail_background.webp" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/images/project-list-page_background.webp" as="image" />
     <style>
       @font-face {
         font-family: 'MPLUS1p';

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -75,6 +75,19 @@
     />
     <link rel="preload" href="%PUBLIC_URL%/images/project-detail_background.webp" as="image" />
     <link rel="preload" href="%PUBLIC_URL%/images/project-list-page_background.webp" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/modal-background.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-achievement.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-design.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-motivation.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-plan.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-solution.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-technology.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/dragon-symbol.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/gold-button.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-plus.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-plus-disabled.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-minus.svg" as="image" />
+    <link rel="preload" href="%PUBLIC_URL%/svg/status-minus-disabled.svg" as="image" />
     <style>
       @font-face {
         font-family: 'MPLUS1p';

--- a/frontend/src/components/ui/modal/Modal.tsx
+++ b/frontend/src/components/ui/modal/Modal.tsx
@@ -5,7 +5,7 @@ import { strokeTextShadow } from 'utils/strokeTextShadow'
 import { convertIntoRGBA } from 'utils/color/convertIntoRGBA'
 import { CrossIcon } from 'components/ui/icon/CrossIcon'
 import { theme } from 'styles/theme'
-import styled, { css } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 
 type Props = {
   title?: string
@@ -16,7 +16,11 @@ type Props = {
 
 export const Modal: FCX<Props> = ({ title, shouldShow, onClickCloseBtn, className, children }) => {
   return (
-    <MuiModal open={shouldShow} onBackdropClick={() => onClickCloseBtn()}>
+    <MuiModal
+      open={shouldShow}
+      onBackdropClick={() => onClickCloseBtn()}
+      BackdropComponent={StyledBackdrop}
+      BackdropProps={{ transitionDuration: 3000 }}>
       <StyledWrapper className={className}>
         <StyledCloseButton onClick={onClickCloseBtn}>
           <StyledCrossIcon color={theme.COLORS.DUSTY_GRAY} strokeLinecap="round" />
@@ -31,6 +35,26 @@ export const Modal: FCX<Props> = ({ title, shouldShow, onClickCloseBtn, classNam
   )
 }
 
+const fadeIn = keyframes`
+from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`
+const StyledBackdrop = styled.div`
+  z-index: ${({ theme }) => theme.Z_INDEX.INDEX_MINUS_1};
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  background-color: ${({ theme }) => convertIntoRGBA(theme.COLORS.BLACK, 0.6)};
+  opacity: 0;
+  will-change: animation, opacity;
+  animation: ${fadeIn} 0.5s forwards linear;
+`
 const StyledWrapper = styled.div`
   z-index: ${({ theme }) => theme.Z_INDEX.MODAL};
   position: absolute;


### PR DESCRIPTION
## 実装の概要
- モーダル内で使う画像をpreloadで取得し、初回のカクつきを若干減らした
- muiのモーダルのoverlayの透過度を下げるついでに`will-change: animation, opacity`を付与してパフォーマンスの向上を狙ったが、効果は感じられなかった

<!-- 概要を入力 -->

Trello #226 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #226 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

### before
https://user-images.githubusercontent.com/47961006/147372208-d202f9af-0b59-4897-aefa-8e2a3b075d78.mov

### after
https://user-images.githubusercontent.com/47961006/147372212-0b31c010-2c3a-4c9e-9009-08fdab51166a.mov

## 目的
モーダルを開いた時のカクつきをなくす


## レビューして欲しいところ

## 不安に思っていること
- 前よりはマシになった感覚はあるものの、やはりまだカクつくことがある
- overlayのカクつきに関しては特に改善が見られなかった
- 原因もよくわからないので、デプロイで改善することを祈りたい

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
