### PR TITLE
fix: 招待URLからプロジェクトに参加した後の挙動を修正

### DIFF
--- a/frontend/src/pages/invitation/index.tsx
+++ b/frontend/src/pages/invitation/index.tsx
@@ -13,7 +13,7 @@ export const Invitation: FC = () => {
 
   const [tryJoinProject] = useJoinProjectMutation({
     onCompleted(data) {
-      navigate(`/projects/${data.joinProject.project.id}`)
+      navigate(`/projects/${data.joinProject.project.id}`, { replace: true })
     },
     onError(err) {
       toast.error('失敗しました')


### PR DESCRIPTION
## 実装の概要
招待URLからプロジェクトに参加、その後ページを戻ろうとしたら変な挙動をしていたので修正

Trello #315 
Closes #315

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
