### PR TITLE
fix: 完了リストにあるタスクのステータスポイントを変更できないように

### DIFF
--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -92,7 +92,7 @@ export const TaskEditModal: FCX<Props> = ({
               />
               <StyledTaskEditStatusPointField
                 id={id}
-                isCompleted={completed_flg}
+                completedFlag={completed_flg}
                 technology={technology}
                 solution={solution}
                 achievement={achievement}

--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -92,7 +92,7 @@ export const TaskEditModal: FCX<Props> = ({
               />
               <StyledTaskEditStatusPointField
                 id={id}
-                completedFlag={completed_flg}
+                isCompleted={completed_flg}
                 technology={technology}
                 solution={solution}
                 achievement={achievement}

--- a/frontend/src/components/models/task/TaskEditModal.tsx
+++ b/frontend/src/components/models/task/TaskEditModal.tsx
@@ -92,6 +92,7 @@ export const TaskEditModal: FCX<Props> = ({
               />
               <StyledTaskEditStatusPointField
                 id={id}
+                completedFlag={completed_flg}
                 technology={technology}
                 solution={solution}
                 achievement={achievement}

--- a/frontend/src/components/models/task/TaskEditStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskEditStatusPointField.tsx
@@ -7,9 +7,14 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { STATUS_TYPE } from 'consts/status'
 import { StatusParam } from 'types/status'
 
-type Props = { id: string } & Record<StatusParam, number>
+type Props = { id: string; completedFlag: boolean } & Record<StatusParam, number>
 
-export const TaskEditStatusPointField: FCX<Props> = ({ className, id, ...initialStatusCounts }) => {
+export const TaskEditStatusPointField: FCX<Props> = ({
+  className,
+  id,
+  completedFlag,
+  ...initialStatusCounts
+}) => {
   const { setStatusCounts, disabled, onClickSaveButton } = useTaskStatusPointEditForm({
     id,
     initialStatusCounts,
@@ -23,6 +28,7 @@ export const TaskEditStatusPointField: FCX<Props> = ({ className, id, ...initial
           status={status}
           statusCounts={initialStatusCounts}
           setStatusCounts={setStatusCounts}
+          completedFlag={completedFlag}
           key={index}
         />
       ))}

--- a/frontend/src/components/models/task/TaskEditStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskEditStatusPointField.tsx
@@ -7,12 +7,12 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { STATUS_TYPE } from 'consts/status'
 import { StatusParam } from 'types/status'
 
-type Props = { id: string; isCompleted: boolean } & Record<StatusParam, number>
+type Props = { id: string; completedFlag: boolean } & Record<StatusParam, number>
 
 export const TaskEditStatusPointField: FCX<Props> = ({
   className,
   id,
-  isCompleted,
+  completedFlag,
   ...initialStatusCounts
 }) => {
   const { setStatusCounts, disabled, onClickSaveButton } = useTaskStatusPointEditForm({
@@ -28,7 +28,7 @@ export const TaskEditStatusPointField: FCX<Props> = ({
           status={status}
           statusCounts={initialStatusCounts}
           setStatusCounts={setStatusCounts}
-          isCompleted={isCompleted}
+          completedFlag={completedFlag}
           key={index}
         />
       ))}

--- a/frontend/src/components/models/task/TaskEditStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskEditStatusPointField.tsx
@@ -7,12 +7,12 @@ import { calculateMinSizeBasedOnFigma } from 'utils/calculateSizeBasedOnFigma'
 import { STATUS_TYPE } from 'consts/status'
 import { StatusParam } from 'types/status'
 
-type Props = { id: string; completedFlag: boolean } & Record<StatusParam, number>
+type Props = { id: string; isCompleted: boolean } & Record<StatusParam, number>
 
 export const TaskEditStatusPointField: FCX<Props> = ({
   className,
   id,
-  completedFlag,
+  isCompleted,
   ...initialStatusCounts
 }) => {
   const { setStatusCounts, disabled, onClickSaveButton } = useTaskStatusPointEditForm({
@@ -28,7 +28,7 @@ export const TaskEditStatusPointField: FCX<Props> = ({
           status={status}
           statusCounts={initialStatusCounts}
           setStatusCounts={setStatusCounts}
-          completedFlag={completedFlag}
+          isCompleted={isCompleted}
           key={index}
         />
       ))}

--- a/frontend/src/components/models/task/TaskStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskStatusPointField.tsx
@@ -13,7 +13,7 @@ type Props = {
   status: StatusParam
   statusCounts: Record<StatusParam, number>
   setStatusCounts: Dispatch<SetStateAction<Record<StatusParam, number>>>
-  isCompleted: boolean
+  completedFlag: boolean
 }
 
 export const TaskStatusPointField: FCX<Props> = ({
@@ -21,7 +21,7 @@ export const TaskStatusPointField: FCX<Props> = ({
   status,
   statusCounts,
   setStatusCounts,
-  isCompleted,
+  completedFlag,
 }) => {
   const { count, setCount, increment, decrement, isDisabledIncrement, isDisabledDecrement } =
     useIncrementAndDecrement(10, 0)
@@ -52,9 +52,9 @@ export const TaskStatusPointField: FCX<Props> = ({
       <StyledStatusName>{convertParamIntoJp(status)}</StyledStatusName>
 
       <StyledCountWrapper>
-        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement || isCompleted} />
+        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement || completedFlag} />
         <StyledCountText>+{count}</StyledCountText>
-        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement || isCompleted} />
+        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement || completedFlag} />
       </StyledCountWrapper>
     </StyledStatusWrapper>
   )

--- a/frontend/src/components/models/task/TaskStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskStatusPointField.tsx
@@ -13,6 +13,7 @@ type Props = {
   status: StatusParam
   statusCounts: Record<StatusParam, number>
   setStatusCounts: Dispatch<SetStateAction<Record<StatusParam, number>>>
+  completedFlag: boolean
 }
 
 export const TaskStatusPointField: FCX<Props> = ({
@@ -20,6 +21,7 @@ export const TaskStatusPointField: FCX<Props> = ({
   status,
   statusCounts,
   setStatusCounts,
+  completedFlag,
 }) => {
   const { count, setCount, increment, decrement, isDisabledIncrement, isDisabledDecrement } =
     useIncrementAndDecrement(10, 0)
@@ -50,9 +52,9 @@ export const TaskStatusPointField: FCX<Props> = ({
       <StyledStatusName>{convertParamIntoJp(status)}</StyledStatusName>
 
       <StyledCountWrapper>
-        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement} />
+        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement || completedFlag} />
         <StyledCountText>+{count}</StyledCountText>
-        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement} />
+        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement || completedFlag} />
       </StyledCountWrapper>
     </StyledStatusWrapper>
   )

--- a/frontend/src/components/models/task/TaskStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskStatusPointField.tsx
@@ -13,7 +13,7 @@ type Props = {
   status: StatusParam
   statusCounts: Record<StatusParam, number>
   setStatusCounts: Dispatch<SetStateAction<Record<StatusParam, number>>>
-  completedFlag: boolean
+  completedFlag?: boolean
 }
 
 export const TaskStatusPointField: FCX<Props> = ({
@@ -21,7 +21,7 @@ export const TaskStatusPointField: FCX<Props> = ({
   status,
   statusCounts,
   setStatusCounts,
-  completedFlag,
+  completedFlag = false,
 }) => {
   const { count, setCount, increment, decrement, isDisabledIncrement, isDisabledDecrement } =
     useIncrementAndDecrement(10, 0)

--- a/frontend/src/components/models/task/TaskStatusPointField.tsx
+++ b/frontend/src/components/models/task/TaskStatusPointField.tsx
@@ -13,7 +13,7 @@ type Props = {
   status: StatusParam
   statusCounts: Record<StatusParam, number>
   setStatusCounts: Dispatch<SetStateAction<Record<StatusParam, number>>>
-  completedFlag: boolean
+  isCompleted: boolean
 }
 
 export const TaskStatusPointField: FCX<Props> = ({
@@ -21,7 +21,7 @@ export const TaskStatusPointField: FCX<Props> = ({
   status,
   statusCounts,
   setStatusCounts,
-  completedFlag,
+  isCompleted,
 }) => {
   const { count, setCount, increment, decrement, isDisabledIncrement, isDisabledDecrement } =
     useIncrementAndDecrement(10, 0)
@@ -52,9 +52,9 @@ export const TaskStatusPointField: FCX<Props> = ({
       <StyledStatusName>{convertParamIntoJp(status)}</StyledStatusName>
 
       <StyledCountWrapper>
-        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement || completedFlag} />
+        <StyledMinusBtn onClick={decrement} disabled={isDisabledDecrement || isCompleted} />
         <StyledCountText>+{count}</StyledCountText>
-        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement || completedFlag} />
+        <StyledPlusBtn onClick={increment} disabled={isDisabledIncrement || isCompleted} />
       </StyledCountWrapper>
     </StyledStatusWrapper>
   )

--- a/frontend/src/hooks/useTaskStatusPointEditForm.ts
+++ b/frontend/src/hooks/useTaskStatusPointEditForm.ts
@@ -14,6 +14,7 @@ type UseTaskStatusPointEditFormReturn = {
 }
 type UseTaskStatusPointEditForm = (args: {
   id: string
+  completedFlag: boolean
   initialStatusCounts: StatusCounts
 }) => UseTaskStatusPointEditFormReturn
 

--- a/frontend/src/hooks/useTaskStatusPointEditForm.ts
+++ b/frontend/src/hooks/useTaskStatusPointEditForm.ts
@@ -14,7 +14,6 @@ type UseTaskStatusPointEditFormReturn = {
 }
 type UseTaskStatusPointEditForm = (args: {
   id: string
-  completedFlag: boolean
   initialStatusCounts: StatusCounts
 }) => UseTaskStatusPointEditFormReturn
 
@@ -23,7 +22,6 @@ type UseTaskStatusPointEditForm = (args: {
  */
 export const useTaskStatusPointEditForm: UseTaskStatusPointEditForm = ({
   id,
-  completedFlag,
   initialStatusCounts,
 }) => {
   const [newStatusCounts, setNewStatusCounts] = useState<StatusCounts>(initialStatusCounts)

--- a/frontend/src/hooks/useTaskStatusPointEditForm.ts
+++ b/frontend/src/hooks/useTaskStatusPointEditForm.ts
@@ -23,6 +23,7 @@ type UseTaskStatusPointEditForm = (args: {
  */
 export const useTaskStatusPointEditForm: UseTaskStatusPointEditForm = ({
   id,
+  completedFlag,
   initialStatusCounts,
 }) => {
   const [newStatusCounts, setNewStatusCounts] = useState<StatusCounts>(initialStatusCounts)


### PR DESCRIPTION
## 実装の概要
完了リストにあるタスクのステータスポイントを変更できないように修正

Trello #321
Closes #321

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
