### PR TITLE
bugfix: ステータスポイントの更新がんできるように

### DIFF
--- a/api/src/tasks/tasks.service.ts
+++ b/api/src/tasks/tasks.service.ts
@@ -496,14 +496,19 @@ export class TasksService {
       where: {
         id: taskId,
       },
-      relations: ['project'],
+      relations: [
+        'project',
+        'project.tasks',
+        'project.groups',
+        'project.groups.user',
+      ],
     });
 
     if (task.project.tasks.map((task) => task.completed_flg === true)) {
       const url = this.config.get('SOCKET_CLIENT_EVENTS');
       const socket = io(url);
       task.project.groups;
-      const usersId = task.project.groups.map((menber) => menber.user.id);
+      const usersId = task.project.groups.map((member) => member.user.id);
       socket.emit('events', {
         sender: '',
         room: 'general',


### PR DESCRIPTION
## 実装の概要
ステータスポイントの更新ができるように修正

Trello #346
Closes #346

## 目的

## レビューして欲しいところ

## 不安に思っていること
タスク編集モーダルを開いているときに他の人がステータスポイントを更新してもモーダル上では更新されない。上手くやればステータスポイントを無限に増やせる

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
