### PR TITLE
fix: プロジェクト作成時にログインしているユーザーが自動アサインされないバグの修正 #358

### DIFF
--- a/frontend/src/hooks/useProjectCreateForm.ts
+++ b/frontend/src/hooks/useProjectCreateForm.ts
@@ -4,7 +4,6 @@ import {
   useCreateProjectMutation,
   CreateProjectMutationVariables,
 } from 'pages/projectList/projectList.gen'
-import { useGetCurrentUserData } from 'hooks/useGetCurrentUserData'
 import toast from 'utils/toast/toast'
 import type { RatingProps } from '@mui/material/Rating'
 import type { UserData } from 'types/userData'
@@ -38,7 +37,6 @@ export const useProjectCreateForm: UseProjectCreateForm<FormInputs> = ({ closeMo
     setValue,
     watch,
   } = useForm<FormInputs>({ mode: 'onChange' })
-  const { currentUserData } = useGetCurrentUserData()
   const [isDisabled, setIsDisabled] = useState<boolean>(true)
   const isComponentMounted = useRef<boolean>(false)
   const watchAllFields = watch()
@@ -46,6 +44,7 @@ export const useProjectCreateForm: UseProjectCreateForm<FormInputs> = ({ closeMo
   const [difficulty, setDifficulty] = useState<number>(1)
   const [createProject] = useCreateProjectMutation({
     onCompleted(data) {
+      setUserData([])
       closeModal()
       toast.success('プロジェクトを作成しました')
     },
@@ -78,13 +77,6 @@ export const useProjectCreateForm: UseProjectCreateForm<FormInputs> = ({ closeMo
       },
     })
   }, [userData, difficulty])
-
-  useEffect(() => {
-    if (!currentUserData) return
-    if (!userData.length) {
-      setUserData([currentUserData])
-    }
-  }, [currentUserData])
 
   useEffect(() => {
     const initializeInputValues = () => {

--- a/frontend/src/hooks/useSearchSameCompanyMember.ts
+++ b/frontend/src/hooks/useSearchSameCompanyMember.ts
@@ -57,15 +57,24 @@ export const useSearchSameCompanyMember: UseSearchSameCompanyMember = ({
   const onBlur = useCallback(() => setShouldShowResult(false), [])
 
   useEffect(() => {
-    // タスク作成後に選択済のユーザーを初期化する
-    if (!userData.length && JSON.stringify(userData) !== JSON.stringify(selectedUserData)) {
-      setSelectedUserData(userData)
+    if (!currentUserData) return
+    if (!userData.length) setSelectedUserData([currentUserData])
+  }, [currentUserData])
+
+  useEffect(() => {
+    // プロジェクト作成後に選択済のユーザーを初期化する
+    const isUserDataPlane = !userData.length || userData.length === 1
+    const hasCreatedProject =
+      isUserDataPlane && JSON.stringify(userData) !== JSON.stringify(selectedUserData)
+
+    if (hasCreatedProject && currentUserData) {
+      setSelectedUserData([currentUserData])
       setValue('')
       cachedSelectedUserData = []
     }
 
     return () => {
-      if (shouldCache) cachedSelectedUserData = selectedUserData
+      if (shouldCache) cachedSelectedUserData = [...selectedUserData]
     }
   }, [userData])
 


### PR DESCRIPTION
## 実装の概要
プロジェクト作成時にログインしているユーザーが自動アサインされないバグを修正

<!-- 概要を入力 -->

Trello #358 <!-- trelloのタスクを進行中に移動したい場合 -->
Closes #358 <!-- issueをcloseさせたい & trelloのタスクを完了に移動したい場合 -->

## 目的

## レビューして欲しいところ

## 不安に思っていること
#357 も直るかと思ったが直らなかった

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
