### PR TITLE
fix: azure storageからモデルを取得

### DIFF
--- a/frontend/src/components/models/egg/Egg.tsx
+++ b/frontend/src/components/models/egg/Egg.tsx
@@ -16,9 +16,11 @@ type GLTFResult = GLTF & {
   }
 }
 
+const eggModelUrl = 'https://haltokyo.blob.core.windows.net/cg-container/egg.glb'
+
 export default function Model({ ...props }: JSX.IntrinsicElements['group']) {
   const group = useRef<THREE.Group>()
-  const { nodes, materials } = useGLTF('/cg/egg.glb') as GLTFResult
+  const { nodes, materials } = useGLTF(eggModelUrl) as GLTFResult
   return (
     <group ref={group} {...props} dispose={null}>
       <group rotation={[Math.PI / 2, 0, 0]} position={[0, 0.25, 0]} scale={0.01}>
@@ -33,4 +35,4 @@ export default function Model({ ...props }: JSX.IntrinsicElements['group']) {
   )
 }
 
-useGLTF.preload('/cg/egg.glb')
+useGLTF.preload(eggModelUrl)

--- a/frontend/src/components/models/monster/Dragon1125.tsx
+++ b/frontend/src/components/models/monster/Dragon1125.tsx
@@ -36,10 +36,12 @@ type ActionProps = {
   actionName: MonsterActionName
 }
 
+const dragonModelUrl = 'https://haltokyo.blob.core.windows.net/cg-container/dragon1125.glb'
+
 export default function Model({ ...props }: JSX.IntrinsicElements['group'] & ActionProps) {
   const group = useRef<THREE.Group>()
   const { actionName } = props
-  const { nodes, materials, animations } = useGLTF('/cg/dragon1125.glb') as GLTFResult
+  const { nodes, materials, animations } = useGLTF(dragonModelUrl) as GLTFResult
   const { actions, mixer } = useAnimations<AnimationClip>(animations, group)
   const [nowActionName, setNowActionName] = useState<MonsterActionName>('idle')
   useEffect(() => {
@@ -81,4 +83,4 @@ export default function Model({ ...props }: JSX.IntrinsicElements['group'] & Act
   )
 }
 
-useGLTF.preload('/cg/dragon1125.glb')
+useGLTF.preload(dragonModelUrl)


### PR DESCRIPTION
## 実装の概要
azure storageからcgのモデルを取得する

Trello #366
Closes #366

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
