### PR TITLE
bugfix: プロジェクト作成時にリストが4つ作成されるバグの修正 #376

### DIFF
--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -128,7 +128,7 @@ export class ProjectsService {
     });
 
     // リストの作成
-    for (let index = 0; index <= 3; index++) {
+    for (let index = 0; index <= 2; index++) {
       const listName = ['未着手', '進行中', '完了'];
 
       const list = this.listRepository.create({


### PR DESCRIPTION
## 実装の概要
プロジェクト作成時にリストが4つ作成される問題を修正

Trello #376
Closes #376

## 目的

## レビューして欲しいところ

## 不安に思っていること

## スケジュール

<!-- マージすべき日、リリースすべき日の指定があれば書く -->

## 関連

<!-- 関係するプルリクエストなどがあれば書く -->

## 今後のタスク

<!-- レビュアーに伝えたいタスクがあればここに記入して伝える -->
